### PR TITLE
Add options to control composed output

### DIFF
--- a/src/plugin/generate-esm.ts
+++ b/src/plugin/generate-esm.ts
@@ -141,13 +141,19 @@ const dtsComment = `
 
 export const generateTypes = (
 	exports: Exports,
+	composedClassesMode: ComposedClassesMode,
 	allowArbitraryNamedExports = false,
 ) => {
 	const variables = new Set<string>();
 	const exportedVariables = Object.entries(exports).flatMap(
-		([exportName, { exportAs }]) => {
+		([exportName, { exportAs, code: value }]) => {
 			const jsVariable = makeLegalIdentifier(exportName);
-			variables.add(`const ${jsVariable}: string;`);
+
+			if (composedClassesMode === 'string' || (composedClassesMode === 'array' && !value.includes(' '))) {
+				variables.add(`const ${jsVariable}: string;`);
+			} else {
+				variables.add(`const ${jsVariable}: string[];`);
+			}
 
 			return Array.from(exportAs).map((exportAsName) => {
 				const exportNameSafe = makeLegalIdentifier(exportAsName);

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -9,7 +9,7 @@ import { shouldKeepOriginalExport, getLocalesConventionFunction } from './locals
 import {
 	generateEsm, generateTypes, type Imports, type Exports,
 } from './generate-esm.js';
-import type { PluginMeta, ExportMode } from './types.js';
+import type { PluginMeta, ExportMode, ComposedClassesMode } from './types.js';
 import { supportsArbitraryModuleNamespace } from './supports-arbitrary-module-namespace.js';
 
 // https://github.com/vitejs/vite/blob/37af8a7be417f1fb2cf9a0d5e9ad90b76ff211b4/packages/vite/src/node/plugins/css.ts#L185
@@ -60,6 +60,15 @@ export type PatchConfig = {
 	 * next to it, containing type definitions for the exported CSS class names
 	 */
 	generateSourceTypes?: boolean;
+
+	/**
+	 * Choose how to output composed classes.
+	 *
+	 * - 'string': space separated string
+	 * - 'array': composed classes as arrays of strings
+	 * - 'all-array': all classes as arrays of strings
+	 */
+	composedClasses?: ComposedClassesMode;
 };
 
 // This plugin is designed to be used by Vite internally

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -68,7 +68,7 @@ export type PatchConfig = {
 	 * - 'array': composed classes as arrays of strings
 	 * - 'all-array': all classes as arrays of strings
 	 */
-	composedClasses?: ComposedClassesMode;
+	composedClassesMode?: ComposedClassesMode;
 };
 
 // This plugin is designed to be used by Vite internally
@@ -97,6 +97,7 @@ export const cssModules = (
 	);
 
 	const exportMode = patchConfig?.exportMode ?? 'both';
+	const composedClassesMode = patchConfig?.composedClassesMode ?? 'string';
 
 	return {
 		name: pluginName,
@@ -283,6 +284,7 @@ export const cssModules = (
 				imports,
 				exports,
 				exportMode,
+				composedClassesMode,
 				allowArbitraryNamedExports,
 			);
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -297,7 +297,7 @@ export const cssModules = (
 					if (fileExists) {
 						await writeFile(
 							`${id}.d.ts`,
-							generateTypes(exports, allowArbitraryNamedExports),
+							generateTypes(exports, composedClassesMode, allowArbitraryNamedExports),
 						);
 					}
 				}

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -21,3 +21,4 @@ export type PluginMeta = {
 };
 
 export type ExportMode = 'both' | 'named' | 'default';
+export type ComposedClassesMode = 'string' | 'array' | 'all-array';

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -126,6 +126,25 @@ export const exportModeBoth = Object.freeze({
 	'postcss.config.js': postcssConfig,
 });
 
+export const composedAndFlat = Object.freeze({
+	'index.js': outdent`
+	export * as style from './style.module.css';
+	`,
+
+	'style.module.css': outdent`
+	.plain {
+	  color: red;
+    }
+
+    .composed {
+      composes: plain;
+      color: blue;
+    }
+	`,
+
+	'postcss.config.js': postcssConfig,
+});
+
 export const defaultAsName = Object.freeze({
 	'index.js': outdent`
 	export * as style from './style.module.css';

--- a/tests/specs/patched/postcss.spec.ts
+++ b/tests/specs/patched/postcss.spec.ts
@@ -551,7 +551,7 @@ export default testSuite(({ describe }) => {
 				await using fixture = await createFixture(fixtures.composedAndFlat);
 
 				const { js } = await viteBuild(fixture.path, {
-					plugins: [patchCssModules({ composedClasses: 'string' })],
+					plugins: [patchCssModules({ composedClassesMode: 'string' })],
 					build: {
 						target: 'es2022',
 					},
@@ -569,7 +569,7 @@ export default testSuite(({ describe }) => {
 				await using fixture = await createFixture(fixtures.composedAndFlat);
 
 				const { js } = await viteBuild(fixture.path, {
-					plugins: [patchCssModules({ composedClasses: 'array' })],
+					plugins: [patchCssModules({ composedClassesMode: 'array' })],
 					build: {
 						target: 'es2022',
 					},
@@ -587,7 +587,7 @@ export default testSuite(({ describe }) => {
 				await using fixture = await createFixture(fixtures.composedAndFlat);
 
 				const { js } = await viteBuild(fixture.path, {
-					plugins: [patchCssModules({ composedClasses: 'all-array' })],
+					plugins: [patchCssModules({ composedClassesMode: 'all-array' })],
 					build: {
 						target: 'es2022',
 					},

--- a/tests/specs/patched/postcss.spec.ts
+++ b/tests/specs/patched/postcss.spec.ts
@@ -551,7 +551,10 @@ export default testSuite(({ describe }) => {
 				await using fixture = await createFixture(fixtures.composedAndFlat);
 
 				const { js } = await viteBuild(fixture.path, {
-					plugins: [patchCssModules({ composedClassesMode: 'string' })],
+					plugins: [patchCssModules({
+						composedClassesMode: 'string',
+						generateSourceTypes: true,
+					})],
 					build: {
 						target: 'es2022',
 					},
@@ -563,13 +566,19 @@ export default testSuite(({ describe }) => {
 						composed: expect.stringMatching(/_composed_\w+ _plain_\w+/),
 					},
 				});
+				const dts = await fixture.readFile('style.module.css.d.ts', 'utf8');
+				expect(dts).toMatch('const plain: string;');
+				expect(dts).toMatch('const composed: string;');
 			});
 
 			test('array', async () => {
 				await using fixture = await createFixture(fixtures.composedAndFlat);
 
 				const { js } = await viteBuild(fixture.path, {
-					plugins: [patchCssModules({ composedClassesMode: 'array' })],
+					plugins: [patchCssModules({
+						composedClassesMode: 'array',
+						generateSourceTypes: true,
+					})],
 					build: {
 						target: 'es2022',
 					},
@@ -581,13 +590,19 @@ export default testSuite(({ describe }) => {
 						composed: [expect.stringMatching(/_composed_\w+/), expect.stringMatching(/_plain_\w+/)],
 					},
 				});
+				const dts = await fixture.readFile('style.module.css.d.ts', 'utf8');
+				expect(dts).toMatch('const plain: string;');
+				expect(dts).toMatch('const composed: string[];');
 			});
 
 			test('all-array', async () => {
 				await using fixture = await createFixture(fixtures.composedAndFlat);
 
 				const { js } = await viteBuild(fixture.path, {
-					plugins: [patchCssModules({ composedClassesMode: 'all-array' })],
+					plugins: [patchCssModules({
+						composedClassesMode: 'all-array',
+						generateSourceTypes: true,
+					})],
 					build: {
 						target: 'es2022',
 					},
@@ -599,6 +614,9 @@ export default testSuite(({ describe }) => {
 						composed: [expect.stringMatching(/_composed_\w+/), expect.stringMatching(/_plain_\w+/)],
 					},
 				});
+				const dts = await fixture.readFile('style.module.css.d.ts', 'utf8');
+				expect(dts).toMatch('const plain: string[];');
+				expect(dts).toMatch('const composed: string[];');
 			});
 		});
 

--- a/tests/specs/patched/postcss.spec.ts
+++ b/tests/specs/patched/postcss.spec.ts
@@ -546,6 +546,62 @@ export default testSuite(({ describe }) => {
 			});
 		});
 
+		describe('composedClasses', () => {
+			test('string', async () => {
+				await using fixture = await createFixture(fixtures.composedAndFlat);
+
+				const { js } = await viteBuild(fixture.path, {
+					plugins: [patchCssModules({ composedClasses: 'string' })],
+					build: {
+						target: 'es2022',
+					},
+				});
+				const exported = await import(base64Module(js));
+				expect(exported).toMatchObject({
+					style: {
+						plain: expect.stringMatching(/_plain_\w+/),
+						composed: expect.stringMatching(/_composed_\w+ _plain_\w+/),
+					},
+				});
+			});
+
+			test('array', async () => {
+				await using fixture = await createFixture(fixtures.composedAndFlat);
+
+				const { js } = await viteBuild(fixture.path, {
+					plugins: [patchCssModules({ composedClasses: 'array' })],
+					build: {
+						target: 'es2022',
+					},
+				});
+				const exported = await import(base64Module(js));
+				expect(exported).toMatchObject({
+					style: {
+						plain: expect.stringMatching(/_plain_\w+/),
+						composed: [expect.stringMatching(/_composed_\w+/), expect.stringMatching(/_plain_\w+/)],
+					},
+				});
+			});
+
+			test('all-array', async () => {
+				await using fixture = await createFixture(fixtures.composedAndFlat);
+
+				const { js } = await viteBuild(fixture.path, {
+					plugins: [patchCssModules({ composedClasses: 'all-array' })],
+					build: {
+						target: 'es2022',
+					},
+				});
+				const exported = await import(base64Module(js));
+				expect(exported).toMatchObject({
+					style: {
+						plain: [expect.stringMatching(/_plain_\w+/)],
+						composed: [expect.stringMatching(/_composed_\w+/), expect.stringMatching(/_plain_\w+/)],
+					},
+				});
+			});
+		});
+
 		test('globalModulePaths', async () => {
 			await using fixture = await createFixture(fixtures.globalModule);
 


### PR DESCRIPTION
Fixes #19

Whilst I take on board the recommendation to propose this to the css modules spec (and have done so in https://github.com/css-modules/css-modules/issues/417), there really isn't really much activity going on there, even when @devongovett makes suggestions for extensions.

So, I raise this PR as a POC based on a patch I've applied locally to unlock my own project to demonstrate how it might work in practice.

I'm well aware it's missing some implementation details (composing an already composed class from another file doesn't work yet), but I just wanted to put this up.