### PR TITLE
Fix the name of generated source type files

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -305,7 +305,7 @@ export const cssModules = (
 					const fileExists = await access(filePath).then(() => true, () => false);
 					if (fileExists) {
 						await writeFile(
-							`${id}.d.ts`,
+							`${filePath}.d.ts`,
 							generateTypes(exports, allowArbitraryNamedExports),
 						);
 					}


### PR DESCRIPTION
Resolves cases where unnecessary .d.ts files are generated with a question mark in their names, alongside the correctly named .d.ts files.