### PR TITLE
fix: generate types according to exportMode

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -313,7 +313,7 @@ export const cssModules = (
 					if (fileExists) {
 						await writeFile(
 							`${filePath}.d.ts`,
-							generateTypes(exports, allowArbitraryNamedExports),
+							generateTypes(exports, exportMode, allowArbitraryNamedExports),
 						);
 					}
 				}


### PR DESCRIPTION
Generate types according to `exportMode`.

~also only warn on 'default' class name when `exportMode = 'named'`. In other cases the 'default' class name can be imported from the default export.~