### PR TITLE
fix: detect cyclic CSS Module dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [develop]
   pull_request:
-    branches: [master, develop]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -293,6 +293,10 @@ Vite delegates bundling each CSS Module to [`postcss-modules`](https://github.co
 
     `postcss-modules` fails silently when it can't resolve a `composes` dependency—missing exports don't throw errors, making CSS bugs harder to catch. ([#16075](https://github.com/vitejs/vite/issues/16075))
 
+4. **Crash on circular `composes` dependencies**
+
+    When two CSS Modules compose from each other, `postcss-modules` triggers a deadlock that crashes the build with an unhelpful internal error. This plugin detects the cycle and throws a descriptive error showing the dependency chain (e.g. `Circular CSS Module dependency: "a.module.css" -> "b.module.css" -> "a.module.css"`).
+
 The `vite-css-modules` plugin fixes these issues by seamlessly integrating CSS Modules into Vite's build process.
 
 ### How does this work?

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
 		"lintroll": "^1.25.0",
 		"lodash.camelcase": "^4.3.0",
 		"manten": "^2.0.0",
+		"nano-spawn": "^2.0.0",
 		"outdent": "^0.8.0",
 		"pkgroll": "^2.27.0",
 		"playwright-chromium": "^1.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       manten:
         specifier: ^2.0.0
         version: 2.0.0
+      nano-spawn:
+        specifier: ^2.0.0
+        version: 2.0.0
       outdent:
         specifier: ^0.8.0
         version: 0.8.0

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
 import path from 'node:path';
 import { readFile, writeFile, access } from 'fs/promises';
 import type { Plugin, ResolvedConfig, CSSModulesOptions } from 'vite';
@@ -18,61 +17,6 @@ import type { transform as LightningcssTransform } from './transformers/lightnin
 import { getCssModuleUrl, cleanUrl, cssModuleRE } from './url-utils.js';
 
 export const pluginName = 'vite:css-modules';
-
-const dependencyTraceStorage = new AsyncLocalStorage<string[]>();
-
-const formatCycleError = (
-	dependencyTrace: string[],
-	dependencyId: string,
-) => {
-	const cycleStart = dependencyTrace.indexOf(dependencyId);
-	const cyclePath = [
-		...dependencyTrace.slice(cycleStart),
-		dependencyId,
-	].map(id => JSON.stringify(path.basename(id))).join(' -> ');
-	return new Error(`Circular CSS Module dependency: ${cyclePath}`);
-};
-
-const withDependencyTrace = async <T>(
-	id: string,
-	callback: () => Promise<T>,
-) => {
-	const dependencyTrace = dependencyTraceStorage.getStore();
-	const cleanId = cleanUrl(id);
-	if (dependencyTrace?.at(-1) === cleanId) {
-		return await callback();
-	}
-	return await dependencyTraceStorage.run(
-		[
-			...(dependencyTrace ?? []),
-			cleanId,
-		],
-		callback,
-	);
-};
-
-const loadExports = async (
-	context: TransformPluginContext,
-	requestId: string,
-	fromId: string,
-) => {
-	const resolved = await context.resolve(requestId, fromId);
-	if (!resolved) {
-		throw new Error(`Cannot resolve "${requestId}" from "${fromId}"`);
-	}
-
-	const dependencyId = cleanUrl(resolved.id);
-	const dependencyTrace = dependencyTraceStorage.getStore();
-	if (dependencyTrace?.includes(dependencyId)) {
-		throw formatCycleError(dependencyTrace, dependencyId);
-	}
-
-	const loaded = await context.load({
-		id: resolved.id,
-	});
-	const pluginMeta = loaded.meta[pluginName] as PluginMeta;
-	return pluginMeta.exports;
-};
 
 export type PatchConfig = {
 
@@ -132,6 +76,119 @@ export const cssModules = (
 	const declarationMap = patchConfig?.declarationMap
 		?? getTsconfig(config.root)?.config.compilerOptions?.declarationMap
 		?? false;
+	const activeDependencies = new Map<string, Map<string, number>>();
+
+	const formatDependencyId = (dependencyId: string) => {
+		const relativeId = path.relative(config.root, dependencyId);
+		return JSON.stringify(relativeId || path.basename(dependencyId));
+	};
+
+	const addActiveDependency = (
+		fromId: string,
+		dependencyId: string,
+	) => {
+		let dependencies = activeDependencies.get(fromId);
+		if (!dependencies) {
+			dependencies = new Map();
+			activeDependencies.set(fromId, dependencies);
+		}
+
+		dependencies.set(
+			dependencyId,
+			(dependencies.get(dependencyId) ?? 0) + 1,
+		);
+	};
+
+	const removeActiveDependency = (
+		fromId: string,
+		dependencyId: string,
+	) => {
+		const dependencies = activeDependencies.get(fromId);
+		if (!dependencies) {
+			return;
+		}
+
+		const nextCount = (dependencies.get(dependencyId) ?? 0) - 1;
+		if (nextCount > 0) {
+			dependencies.set(dependencyId, nextCount);
+			return;
+		}
+
+		dependencies.delete(dependencyId);
+		if (dependencies.size === 0) {
+			activeDependencies.delete(fromId);
+		}
+	};
+
+	const findDependencyPath = (
+		fromId: string,
+		targetId: string,
+		visited = new Set<string>(),
+	): string[] | undefined => {
+		if (fromId === targetId) {
+			return [fromId];
+		}
+
+		if (visited.has(fromId)) {
+			return;
+		}
+		visited.add(fromId);
+
+		const dependencies = activeDependencies.get(fromId);
+		if (!dependencies) {
+			return;
+		}
+
+		for (const [dependencyId, count] of dependencies) {
+			if (count === 0) {
+				continue;
+			}
+
+			const dependencyPath = findDependencyPath(dependencyId, targetId, visited);
+			if (dependencyPath) {
+				return [
+					fromId,
+					...dependencyPath,
+				];
+			}
+		}
+	};
+
+	const formatCycleError = (cyclePath: string[]) => new Error(
+		`Circular CSS Module dependency: ${cyclePath.map(formatDependencyId).join(' -> ')}`,
+	);
+
+	const loadExports = async (
+		context: TransformPluginContext,
+		requestId: string,
+		fromId: string,
+	) => {
+		const resolved = await context.resolve(requestId, fromId);
+		if (!resolved) {
+			throw new Error(`Cannot resolve "${requestId}" from "${fromId}"`);
+		}
+
+		const importerId = cleanUrl(fromId);
+		const dependencyId = cleanUrl(resolved.id);
+		const dependencyPath = findDependencyPath(dependencyId, importerId);
+		if (dependencyPath) {
+			throw formatCycleError([
+				...dependencyPath,
+				dependencyId,
+			]);
+		}
+
+		addActiveDependency(importerId, dependencyId);
+		try {
+			const loaded = await context.load({
+				id: resolved.id,
+			});
+			const pluginMeta = loaded.meta[pluginName] as PluginMeta;
+			return pluginMeta.exports;
+		} finally {
+			removeActiveDependency(importerId, dependencyId);
+		}
+	};
 
 	let isVitest = false;
 
@@ -177,237 +234,235 @@ export const cssModules = (
 					return;
 				}
 
-				return await withDependencyTrace(id, async () => {
 				/**
 				 * Handle Vitest disabling CSS
 				 * https://github.com/vitest-dev/vitest/blob/v2.1.8/packages/vitest/src/node/plugins/cssEnabler.ts#L55-L68
 				 */
-					if (inputCss === '') {
-						if (!isVitest) {
-							const checkVitest = config.plugins.some(plugin => plugin.name === 'vitest:css-disable');
-							if (checkVitest) {
-								isVitest = true;
-							}
-						}
-						if (isVitest) {
-							return {
-								code: 'export default {};',
-								map: null,
-							};
+				if (inputCss === '') {
+					if (!isVitest) {
+						const checkVitest = config.plugins.some(plugin => plugin.name === 'vitest:css-disable');
+						if (checkVitest) {
+							isVitest = true;
 						}
 					}
+					if (isVitest) {
+						return {
+							code: 'export default {};',
+							map: null,
+						};
+					}
+				}
 
-					const cssModule = transform(
-						inputCss,
+				const cssModule = transform(
+					inputCss,
 
-						/**
+					/**
 					 * Relative path from project root to get stable CSS modules hash
 					 * https://github.com/vitejs/vite/blob/57463fc53fedc8f29e05ef3726f156a6daf65a94/packages/vite/src/node/plugins/css.ts#L2690
 					 */
-						cleanUrl(path.relative(config.root, id)),
-						isLightningCss ? lightningCssOptions : cssModuleConfig,
-						devSourcemap,
-					);
+					cleanUrl(path.relative(config.root, id)),
+					isLightningCss ? lightningCssOptions : cssModuleConfig,
+					devSourcemap,
+				);
 
-					let outputCss = cssModule.code;
-					const imports: Imports = new Map();
-					let counter = 0;
+				let outputCss = cssModule.code;
+				const imports: Imports = new Map();
+				let counter = 0;
 
-					const keepOriginalExport = shouldKeepOriginalExport(cssModuleConfig);
-					const localsConventionFunction = getLocalesConventionFunction(cssModuleConfig);
+				const keepOriginalExport = shouldKeepOriginalExport(cssModuleConfig);
+				const localsConventionFunction = getLocalesConventionFunction(cssModuleConfig);
 
-					const registerImport = (
-						fromFile: string,
-						exportName?: string,
-					) => {
-						let importFrom = imports.get(fromFile);
-						if (!importFrom) {
-							importFrom = {};
-							imports.set(fromFile, importFrom);
-						}
+				const registerImport = (
+					fromFile: string,
+					exportName?: string,
+				) => {
+					let importFrom = imports.get(fromFile);
+					if (!importFrom) {
+						importFrom = {};
+						imports.set(fromFile, importFrom);
+					}
 
-						if (!exportName) {
-							return;
-						}
+					if (!exportName) {
+						return;
+					}
 
-						if (!importFrom[exportName]) {
-							importFrom[exportName] = `_${counter}`;
-							counter += 1;
-						}
-						return importFrom[exportName];
-					};
+					if (!importFrom[exportName]) {
+						importFrom[exportName] = `_${counter}`;
+						counter += 1;
+					}
+					return importFrom[exportName];
+				};
 
-					/**
+				/**
 				 * Passes Promise.all result to Object.fromEntries to preserve export order
 				 * This avoids unnecessary git diffs from non-deterministic ordering
 				 * (e.g. generated types) when the CSS module itself hasn't changed
 				 */
-					const exportEntries = await Promise.all(
-						Object.entries(cssModule.exports).map(async ([exportName, exported]) => {
-							if (
-								exportName === 'default'
+				const exportEntries = await Promise.all(
+					Object.entries(cssModule.exports).map(async ([exportName, exported]) => {
+						if (
+							exportName === 'default'
 						&& exportMode === 'both'
-							) {
-								this.warn('With `exportMode: both`, you cannot use "default" as a class name as it conflicts with the default export. Set `exportMode` to `default` or `named` to use "default" as a class name.');
+						) {
+							this.warn('With `exportMode: both`, you cannot use "default" as a class name as it conflicts with the default export. Set `exportMode` to `default` or `named` to use "default" as a class name.');
+						}
+
+						const exportAs = new Set<string>();
+						if (keepOriginalExport) {
+							exportAs.add(exportName);
+						}
+
+						let code: string;
+						let resolved: string;
+						if (typeof exported === 'string') {
+							const transformedExport = localsConventionFunction?.(exportName, exportName, id);
+							if (transformedExport) {
+								exportAs.add(transformedExport);
+							}
+							code = exported;
+							resolved = exported;
+						} else {
+							const transformedExport = localsConventionFunction?.(exportName, exported.name, id);
+							if (transformedExport) {
+								exportAs.add(transformedExport);
 							}
 
-							const exportAs = new Set<string>();
-							if (keepOriginalExport) {
-								exportAs.add(exportName);
-							}
-
-							let code: string;
-							let resolved: string;
-							if (typeof exported === 'string') {
-								const transformedExport = localsConventionFunction?.(exportName, exportName, id);
-								if (transformedExport) {
-									exportAs.add(transformedExport);
-								}
-								code = exported;
-								resolved = exported;
-							} else {
-								const transformedExport = localsConventionFunction?.(exportName, exported.name, id);
-								if (transformedExport) {
-									exportAs.add(transformedExport);
-								}
-
-								// Collect composed classes
-								const composedClasses = await Promise.all(
-									exported.composes.map(async (dep) => {
-										if (dep.type === 'dependency') {
-											const loaded = await loadExports(this, getCssModuleUrl(dep.specifier), id);
-											const exportedEntry = loaded[dep.name]!;
-											if (!exportedEntry) {
-												throw new Error(`Cannot resolve ${JSON.stringify(dep.name)} from ${JSON.stringify(dep.specifier)}`);
-											}
-											const [exportAsName] = Array.from(exportedEntry.exportAs);
-											const importedAs = registerImport(dep.specifier, exportAsName)!;
-											return {
-												resolved: exportedEntry.resolved,
-												code: `\${${importedAs}}`,
-											};
+							// Collect composed classes
+							const composedClasses = await Promise.all(
+								exported.composes.map(async (dep) => {
+									if (dep.type === 'dependency') {
+										const loaded = await loadExports(this, getCssModuleUrl(dep.specifier), id);
+										const exportedEntry = loaded[dep.name]!;
+										if (!exportedEntry) {
+											throw new Error(`Cannot resolve ${JSON.stringify(dep.name)} from ${JSON.stringify(dep.specifier)}`);
 										}
-
+										const [exportAsName] = Array.from(exportedEntry.exportAs);
+										const importedAs = registerImport(dep.specifier, exportAsName)!;
 										return {
-											resolved: dep.name,
-											code: dep.name,
+											resolved: exportedEntry.resolved,
+											code: `\${${importedAs}}`,
 										};
-									}),
-								);
-								code = [exported.name, ...composedClasses.map(c => c.code)].join(' ');
-								resolved = [exported.name, ...composedClasses.map(c => c.resolved)].join(' ');
+									}
+
+									return {
+										resolved: dep.name,
+										code: dep.name,
+									};
+								}),
+							);
+							code = [exported.name, ...composedClasses.map(c => c.code)].join(' ');
+							resolved = [exported.name, ...composedClasses.map(c => c.resolved)].join(' ');
+						}
+
+						return [
+							exportName,
+							{
+								code,
+								resolved,
+								exportAs,
+							},
+						] as const;
+					}),
+				);
+
+				const exports: Exports = Object.fromEntries(exportEntries);
+
+				let { map } = cssModule;
+
+				// Inject CSS Modules values
+				const references = Object.entries(cssModule.references);
+				if (references.length > 0) {
+					const ms = new MagicString(outputCss);
+					await Promise.all(
+						references.map(async ([placeholder, source]) => {
+							const loaded = await loadExports(this, getCssModuleUrl(source.specifier), id);
+							const exported = loaded[source.name];
+							if (!exported) {
+								throw new Error(`Cannot resolve "${source.name}" from "${source.specifier}"`);
 							}
 
-							return [
-								exportName,
-								{
-									code,
-									resolved,
-									exportAs,
-								},
-							] as const;
+							registerImport(source.specifier);
+							ms.replaceAll(placeholder, exported.code);
 						}),
 					);
+					outputCss = ms.toString();
 
-					const exports: Exports = Object.fromEntries(exportEntries);
+					if (map) {
+						const newMap = remapping(
+							[
+								ms.generateMap({
+									source: id,
+									file: id,
+									includeContent: true,
+								}),
+								map,
+							] as SourceMapInput[],
+							() => null,
+						) as ExistingRawSourceMap;
 
-					let { map } = cssModule;
-
-					// Inject CSS Modules values
-					const references = Object.entries(cssModule.references);
-					if (references.length > 0) {
-						const ms = new MagicString(outputCss);
-						await Promise.all(
-							references.map(async ([placeholder, source]) => {
-								const loaded = await loadExports(this, getCssModuleUrl(source.specifier), id);
-								const exported = loaded[source.name];
-								if (!exported) {
-									throw new Error(`Cannot resolve "${source.name}" from "${source.specifier}"`);
-								}
-
-								registerImport(source.specifier);
-								ms.replaceAll(placeholder, exported.code);
-							}),
-						);
-						outputCss = ms.toString();
-
-						if (map) {
-							const newMap = remapping(
-								[
-									ms.generateMap({
-										source: id,
-										file: id,
-										includeContent: true,
-									}),
-									map,
-								] as SourceMapInput[],
-								() => null,
-							) as ExistingRawSourceMap;
-
-							map = newMap;
-						}
+						map = newMap;
 					}
+				}
 
-					if (
-						'getJSON' in cssModuleConfig
+				if (
+					'getJSON' in cssModuleConfig
 				&& typeof cssModuleConfig.getJSON === 'function'
-					) {
-						const json: Record<string, string> = {};
-						for (const exported of Object.values(exports)) {
-							for (const exportAs of exported.exportAs) {
-								json[exportAs] = exported.resolved;
-							}
+				) {
+					const json: Record<string, string> = {};
+					for (const exported of Object.values(exports)) {
+						for (const exportAs of exported.exportAs) {
+							json[exportAs] = exported.resolved;
 						}
-
-						cssModuleConfig.getJSON(id, json, id);
 					}
 
-					const jsCode = generateEsm(
-						imports,
-						exports,
-						exportMode,
-						allowArbitraryNamedExports,
-					);
+					cssModuleConfig.getJSON(id, json, id);
+				}
 
-					if (patchConfig?.generateSourceTypes) {
-						const filePath = id.split('?', 2)[0];
+				const jsCode = generateEsm(
+					imports,
+					exports,
+					exportMode,
+					allowArbitraryNamedExports,
+				);
 
-						// Only generate types for importable module files
-						if (filePath && cssModuleRE.test(filePath)) {
-							const fileExists = await access(filePath).then(() => true, () => false);
-							if (fileExists) {
-								const dtsPath = `${filePath}.d.ts`;
-								const originalCss = originalCssCache?.get(filePath);
-								const sourceMapOptions = declarationMap && originalCss
-									? {
-										sourceFileName: path.basename(filePath),
-										classPositions: cssClassPositions(originalCss, { fileName: filePath }),
-									}
-									: undefined;
-								const newContent = generateTypes(
-									exports, exportMode, allowArbitraryNamedExports, sourceMapOptions,
-								);
+				if (patchConfig?.generateSourceTypes) {
+					const filePath = id.split('?', 2)[0];
 
-								// Skip write if content unchanged to avoid triggering file watchers
-								const existingContent = await readFile(dtsPath, 'utf8').catch(() => null);
-								if (existingContent !== newContent) {
-									await writeFile(dtsPath, newContent);
+					// Only generate types for importable module files
+					if (filePath && cssModuleRE.test(filePath)) {
+						const fileExists = await access(filePath).then(() => true, () => false);
+						if (fileExists) {
+							const dtsPath = `${filePath}.d.ts`;
+							const originalCss = originalCssCache?.get(filePath);
+							const sourceMapOptions = declarationMap && originalCss
+								? {
+									sourceFileName: path.basename(filePath),
+									classPositions: cssClassPositions(originalCss, { fileName: filePath }),
 								}
+								: undefined;
+							const newContent = generateTypes(
+								exports, exportMode, allowArbitraryNamedExports, sourceMapOptions,
+							);
+
+							// Skip write if content unchanged to avoid triggering file watchers
+							const existingContent = await readFile(dtsPath, 'utf8').catch(() => null);
+							if (existingContent !== newContent) {
+								await writeFile(dtsPath, newContent);
 							}
 						}
 					}
+				}
 
-					return {
-						code: jsCode,
-						map: map ?? { mappings: '' },
-						meta: {
-							[pluginName]: {
-								css: outputCss,
-								exports,
-							} satisfies PluginMeta,
-						},
-					};
-				});
+				return {
+					code: jsCode,
+					map: map ?? { mappings: '' },
+					meta: {
+						[pluginName]: {
+							css: outputCss,
+							exports,
+						} satisfies PluginMeta,
+					},
+				};
 			},
 		},
 	};

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -78,15 +78,27 @@ export const cssModules = (
 		?? false;
 
 	/*
-	 * Track active loading edges for cycle detection.
+	 * Cycle detection for CSS Module `composes` dependencies.
 	 *
-	 * When module A composes from B, context.load(B) triggers B's transform.
-	 * If B composes from A, context.load(A) deadlocks because A's transform
-	 * is suspended waiting for B. We detect this by tracking A→B as an active
-	 * edge and checking for cycles before each load.
+	 * Problem: when A composes from B, we call context.load(B) which triggers
+	 * B's transform. If B composes from A, B's transform calls context.load(A).
+	 * But A's transform is already suspended waiting for B — deadlock. Rollup
+	 * crashes with a generic "Unexpected early exit" instead of a useful error.
+	 *
+	 * Solution: track which module→dependency edges are currently in-flight.
+	 * Before loading a dependency, walk the active edges to check if it would
+	 * create a cycle back to the current module. If so, throw a descriptive
+	 * error instead of deadlocking.
+	 *
+	 * Why shared mutable state (not a passed-through Set): the call chain is
+	 * broken by Rollup's plugin pipeline — context.load() triggers a separate
+	 * transform invocation, so we can't pass parameters between them. The
+	 * activeEdges map is the bridge between independently-invoked transforms.
 	 */
 	const activeEdges = new Map<string, Set<string>>();
 
+	// DFS through active edges to find a path from fromId back to targetId.
+	// Returns the cycle path if found, or undefined if no cycle exists.
 	const findCyclePath = (
 		fromId: string,
 		targetId: string,
@@ -113,6 +125,8 @@ export const cssModules = (
 		}
 	};
 
+	// Load and return the CSS Module exports from a composed dependency.
+	// Called during transform when processing `composes: class from './dep.css'`.
 	const loadExports = async (
 		context: TransformPluginContext,
 		requestId: string,
@@ -126,6 +140,7 @@ export const cssModules = (
 		const importerId = cleanUrl(fromId);
 		const dependencyId = cleanUrl(resolved.id);
 
+		// Check if loading this dependency would create a cycle
 		const cyclePath = findCyclePath(dependencyId, importerId);
 		if (cyclePath) {
 			const formatId = (id: string) => {
@@ -137,6 +152,7 @@ export const cssModules = (
 			);
 		}
 
+		// Record this edge as active while the dependency loads
 		let dependencies = activeEdges.get(importerId);
 		if (!dependencies) {
 			dependencies = new Set();
@@ -151,6 +167,7 @@ export const cssModules = (
 			const pluginMeta = loaded.meta[pluginName] as PluginMeta;
 			return pluginMeta.exports;
 		} finally {
+			// Clean up the active edge after load completes (or fails)
 			dependencies.delete(dependencyId);
 			if (dependencies.size === 0) {
 				activeEdges.delete(importerId);

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import path from 'node:path';
 import { readFile, writeFile, access } from 'fs/promises';
 import type { Plugin, ResolvedConfig, CSSModulesOptions } from 'vite';
@@ -18,6 +19,38 @@ import { getCssModuleUrl, cleanUrl, cssModuleRE } from './url-utils.js';
 
 export const pluginName = 'vite:css-modules';
 
+const dependencyTraceStorage = new AsyncLocalStorage<string[]>();
+
+const formatCycleError = (
+	dependencyTrace: string[],
+	dependencyId: string,
+) => {
+	const cycleStart = dependencyTrace.indexOf(dependencyId);
+	const cyclePath = [
+		...dependencyTrace.slice(cycleStart),
+		dependencyId,
+	].map(id => JSON.stringify(path.basename(id))).join(' -> ');
+	return new Error(`Circular CSS Module dependency: ${cyclePath}`);
+};
+
+const withDependencyTrace = async <T>(
+	id: string,
+	callback: () => Promise<T>,
+) => {
+	const dependencyTrace = dependencyTraceStorage.getStore();
+	const cleanId = cleanUrl(id);
+	if (dependencyTrace?.at(-1) === cleanId) {
+		return await callback();
+	}
+	return await dependencyTraceStorage.run(
+		[
+			...(dependencyTrace ?? []),
+			cleanId,
+		],
+		callback,
+	);
+};
+
 const loadExports = async (
 	context: TransformPluginContext,
 	requestId: string,
@@ -27,6 +60,13 @@ const loadExports = async (
 	if (!resolved) {
 		throw new Error(`Cannot resolve "${requestId}" from "${fromId}"`);
 	}
+
+	const dependencyId = cleanUrl(resolved.id);
+	const dependencyTrace = dependencyTraceStorage.getStore();
+	if (dependencyTrace?.includes(dependencyId)) {
+		throw formatCycleError(dependencyTrace, dependencyId);
+	}
+
 	const loaded = await context.load({
 		id: resolved.id,
 	});
@@ -137,235 +177,237 @@ export const cssModules = (
 					return;
 				}
 
+				return await withDependencyTrace(id, async () => {
 				/**
 				 * Handle Vitest disabling CSS
 				 * https://github.com/vitest-dev/vitest/blob/v2.1.8/packages/vitest/src/node/plugins/cssEnabler.ts#L55-L68
 				 */
-				if (inputCss === '') {
-					if (!isVitest) {
-						const checkVitest = config.plugins.some(plugin => plugin.name === 'vitest:css-disable');
-						if (checkVitest) {
-							isVitest = true;
+					if (inputCss === '') {
+						if (!isVitest) {
+							const checkVitest = config.plugins.some(plugin => plugin.name === 'vitest:css-disable');
+							if (checkVitest) {
+								isVitest = true;
+							}
+						}
+						if (isVitest) {
+							return {
+								code: 'export default {};',
+								map: null,
+							};
 						}
 					}
-					if (isVitest) {
-						return {
-							code: 'export default {};',
-							map: null,
-						};
-					}
-				}
 
-				const cssModule = transform(
-					inputCss,
+					const cssModule = transform(
+						inputCss,
 
-					/**
+						/**
 					 * Relative path from project root to get stable CSS modules hash
 					 * https://github.com/vitejs/vite/blob/57463fc53fedc8f29e05ef3726f156a6daf65a94/packages/vite/src/node/plugins/css.ts#L2690
 					 */
-					cleanUrl(path.relative(config.root, id)),
-					isLightningCss ? lightningCssOptions : cssModuleConfig,
-					devSourcemap,
-				);
+						cleanUrl(path.relative(config.root, id)),
+						isLightningCss ? lightningCssOptions : cssModuleConfig,
+						devSourcemap,
+					);
 
-				let outputCss = cssModule.code;
-				const imports: Imports = new Map();
-				let counter = 0;
+					let outputCss = cssModule.code;
+					const imports: Imports = new Map();
+					let counter = 0;
 
-				const keepOriginalExport = shouldKeepOriginalExport(cssModuleConfig);
-				const localsConventionFunction = getLocalesConventionFunction(cssModuleConfig);
+					const keepOriginalExport = shouldKeepOriginalExport(cssModuleConfig);
+					const localsConventionFunction = getLocalesConventionFunction(cssModuleConfig);
 
-				const registerImport = (
-					fromFile: string,
-					exportName?: string,
-				) => {
-					let importFrom = imports.get(fromFile);
-					if (!importFrom) {
-						importFrom = {};
-						imports.set(fromFile, importFrom);
-					}
+					const registerImport = (
+						fromFile: string,
+						exportName?: string,
+					) => {
+						let importFrom = imports.get(fromFile);
+						if (!importFrom) {
+							importFrom = {};
+							imports.set(fromFile, importFrom);
+						}
 
-					if (!exportName) {
-						return;
-					}
+						if (!exportName) {
+							return;
+						}
 
-					if (!importFrom[exportName]) {
-						importFrom[exportName] = `_${counter}`;
-						counter += 1;
-					}
-					return importFrom[exportName];
-				};
+						if (!importFrom[exportName]) {
+							importFrom[exportName] = `_${counter}`;
+							counter += 1;
+						}
+						return importFrom[exportName];
+					};
 
-				/**
+					/**
 				 * Passes Promise.all result to Object.fromEntries to preserve export order
 				 * This avoids unnecessary git diffs from non-deterministic ordering
 				 * (e.g. generated types) when the CSS module itself hasn't changed
 				 */
-				const exportEntries = await Promise.all(
-					Object.entries(cssModule.exports).map(async ([exportName, exported]) => {
-						if (
-							exportName === 'default'
+					const exportEntries = await Promise.all(
+						Object.entries(cssModule.exports).map(async ([exportName, exported]) => {
+							if (
+								exportName === 'default'
 						&& exportMode === 'both'
-						) {
-							this.warn('With `exportMode: both`, you cannot use "default" as a class name as it conflicts with the default export. Set `exportMode` to `default` or `named` to use "default" as a class name.');
-						}
-
-						const exportAs = new Set<string>();
-						if (keepOriginalExport) {
-							exportAs.add(exportName);
-						}
-
-						let code: string;
-						let resolved: string;
-						if (typeof exported === 'string') {
-							const transformedExport = localsConventionFunction?.(exportName, exportName, id);
-							if (transformedExport) {
-								exportAs.add(transformedExport);
-							}
-							code = exported;
-							resolved = exported;
-						} else {
-							const transformedExport = localsConventionFunction?.(exportName, exported.name, id);
-							if (transformedExport) {
-								exportAs.add(transformedExport);
+							) {
+								this.warn('With `exportMode: both`, you cannot use "default" as a class name as it conflicts with the default export. Set `exportMode` to `default` or `named` to use "default" as a class name.');
 							}
 
-							// Collect composed classes
-							const composedClasses = await Promise.all(
-								exported.composes.map(async (dep) => {
-									if (dep.type === 'dependency') {
-										const loaded = await loadExports(this, getCssModuleUrl(dep.specifier), id);
-										const exportedEntry = loaded[dep.name]!;
-										if (!exportedEntry) {
-											throw new Error(`Cannot resolve ${JSON.stringify(dep.name)} from ${JSON.stringify(dep.specifier)}`);
+							const exportAs = new Set<string>();
+							if (keepOriginalExport) {
+								exportAs.add(exportName);
+							}
+
+							let code: string;
+							let resolved: string;
+							if (typeof exported === 'string') {
+								const transformedExport = localsConventionFunction?.(exportName, exportName, id);
+								if (transformedExport) {
+									exportAs.add(transformedExport);
+								}
+								code = exported;
+								resolved = exported;
+							} else {
+								const transformedExport = localsConventionFunction?.(exportName, exported.name, id);
+								if (transformedExport) {
+									exportAs.add(transformedExport);
+								}
+
+								// Collect composed classes
+								const composedClasses = await Promise.all(
+									exported.composes.map(async (dep) => {
+										if (dep.type === 'dependency') {
+											const loaded = await loadExports(this, getCssModuleUrl(dep.specifier), id);
+											const exportedEntry = loaded[dep.name]!;
+											if (!exportedEntry) {
+												throw new Error(`Cannot resolve ${JSON.stringify(dep.name)} from ${JSON.stringify(dep.specifier)}`);
+											}
+											const [exportAsName] = Array.from(exportedEntry.exportAs);
+											const importedAs = registerImport(dep.specifier, exportAsName)!;
+											return {
+												resolved: exportedEntry.resolved,
+												code: `\${${importedAs}}`,
+											};
 										}
-										const [exportAsName] = Array.from(exportedEntry.exportAs);
-										const importedAs = registerImport(dep.specifier, exportAsName)!;
+
 										return {
-											resolved: exportedEntry.resolved,
-											code: `\${${importedAs}}`,
+											resolved: dep.name,
+											code: dep.name,
 										};
-									}
-
-									return {
-										resolved: dep.name,
-										code: dep.name,
-									};
-								}),
-							);
-							code = [exported.name, ...composedClasses.map(c => c.code)].join(' ');
-							resolved = [exported.name, ...composedClasses.map(c => c.resolved)].join(' ');
-						}
-
-						return [
-							exportName,
-							{
-								code,
-								resolved,
-								exportAs,
-							},
-						] as const;
-					}),
-				);
-
-				const exports: Exports = Object.fromEntries(exportEntries);
-
-				let { map } = cssModule;
-
-				// Inject CSS Modules values
-				const references = Object.entries(cssModule.references);
-				if (references.length > 0) {
-					const ms = new MagicString(outputCss);
-					await Promise.all(
-						references.map(async ([placeholder, source]) => {
-							const loaded = await loadExports(this, getCssModuleUrl(source.specifier), id);
-							const exported = loaded[source.name];
-							if (!exported) {
-								throw new Error(`Cannot resolve "${source.name}" from "${source.specifier}"`);
+									}),
+								);
+								code = [exported.name, ...composedClasses.map(c => c.code)].join(' ');
+								resolved = [exported.name, ...composedClasses.map(c => c.resolved)].join(' ');
 							}
 
-							registerImport(source.specifier);
-							ms.replaceAll(placeholder, exported.code);
+							return [
+								exportName,
+								{
+									code,
+									resolved,
+									exportAs,
+								},
+							] as const;
 						}),
 					);
-					outputCss = ms.toString();
 
-					if (map) {
-						const newMap = remapping(
-							[
-								ms.generateMap({
-									source: id,
-									file: id,
-									includeContent: true,
-								}),
-								map,
-							] as SourceMapInput[],
-							() => null,
-						) as ExistingRawSourceMap;
+					const exports: Exports = Object.fromEntries(exportEntries);
 
-						map = newMap;
-					}
-				}
+					let { map } = cssModule;
 
-				if (
-					'getJSON' in cssModuleConfig
-				&& typeof cssModuleConfig.getJSON === 'function'
-				) {
-					const json: Record<string, string> = {};
-					for (const exported of Object.values(exports)) {
-						for (const exportAs of exported.exportAs) {
-							json[exportAs] = exported.resolved;
+					// Inject CSS Modules values
+					const references = Object.entries(cssModule.references);
+					if (references.length > 0) {
+						const ms = new MagicString(outputCss);
+						await Promise.all(
+							references.map(async ([placeholder, source]) => {
+								const loaded = await loadExports(this, getCssModuleUrl(source.specifier), id);
+								const exported = loaded[source.name];
+								if (!exported) {
+									throw new Error(`Cannot resolve "${source.name}" from "${source.specifier}"`);
+								}
+
+								registerImport(source.specifier);
+								ms.replaceAll(placeholder, exported.code);
+							}),
+						);
+						outputCss = ms.toString();
+
+						if (map) {
+							const newMap = remapping(
+								[
+									ms.generateMap({
+										source: id,
+										file: id,
+										includeContent: true,
+									}),
+									map,
+								] as SourceMapInput[],
+								() => null,
+							) as ExistingRawSourceMap;
+
+							map = newMap;
 						}
 					}
 
-					cssModuleConfig.getJSON(id, json, id);
-				}
+					if (
+						'getJSON' in cssModuleConfig
+				&& typeof cssModuleConfig.getJSON === 'function'
+					) {
+						const json: Record<string, string> = {};
+						for (const exported of Object.values(exports)) {
+							for (const exportAs of exported.exportAs) {
+								json[exportAs] = exported.resolved;
+							}
+						}
 
-				const jsCode = generateEsm(
-					imports,
-					exports,
-					exportMode,
-					allowArbitraryNamedExports,
-				);
+						cssModuleConfig.getJSON(id, json, id);
+					}
 
-				if (patchConfig?.generateSourceTypes) {
-					const filePath = id.split('?', 2)[0];
+					const jsCode = generateEsm(
+						imports,
+						exports,
+						exportMode,
+						allowArbitraryNamedExports,
+					);
 
-					// Only generate types for importable module files
-					if (filePath && cssModuleRE.test(filePath)) {
-						const fileExists = await access(filePath).then(() => true, () => false);
-						if (fileExists) {
-							const dtsPath = `${filePath}.d.ts`;
-							const originalCss = originalCssCache?.get(filePath);
-							const sourceMapOptions = declarationMap && originalCss
-								? {
-									sourceFileName: path.basename(filePath),
-									classPositions: cssClassPositions(originalCss, { fileName: filePath }),
+					if (patchConfig?.generateSourceTypes) {
+						const filePath = id.split('?', 2)[0];
+
+						// Only generate types for importable module files
+						if (filePath && cssModuleRE.test(filePath)) {
+							const fileExists = await access(filePath).then(() => true, () => false);
+							if (fileExists) {
+								const dtsPath = `${filePath}.d.ts`;
+								const originalCss = originalCssCache?.get(filePath);
+								const sourceMapOptions = declarationMap && originalCss
+									? {
+										sourceFileName: path.basename(filePath),
+										classPositions: cssClassPositions(originalCss, { fileName: filePath }),
+									}
+									: undefined;
+								const newContent = generateTypes(
+									exports, exportMode, allowArbitraryNamedExports, sourceMapOptions,
+								);
+
+								// Skip write if content unchanged to avoid triggering file watchers
+								const existingContent = await readFile(dtsPath, 'utf8').catch(() => null);
+								if (existingContent !== newContent) {
+									await writeFile(dtsPath, newContent);
 								}
-								: undefined;
-							const newContent = generateTypes(
-								exports, exportMode, allowArbitraryNamedExports, sourceMapOptions,
-							);
-
-							// Skip write if content unchanged to avoid triggering file watchers
-							const existingContent = await readFile(dtsPath, 'utf8').catch(() => null);
-							if (existingContent !== newContent) {
-								await writeFile(dtsPath, newContent);
 							}
 						}
 					}
-				}
 
-				return {
-					code: jsCode,
-					map: map ?? { mappings: '' },
-					meta: {
-						[pluginName]: {
-							css: outputCss,
-							exports,
-						} satisfies PluginMeta,
-					},
-				};
+					return {
+						code: jsCode,
+						map: map ?? { mappings: '' },
+						meta: {
+							[pluginName]: {
+								css: outputCss,
+								exports,
+							} satisfies PluginMeta,
+						},
+					};
+				});
 			},
 		},
 	};

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -76,51 +76,18 @@ export const cssModules = (
 	const declarationMap = patchConfig?.declarationMap
 		?? getTsconfig(config.root)?.config.compilerOptions?.declarationMap
 		?? false;
-	const activeDependencies = new Map<string, Map<string, number>>();
 
-	const formatDependencyId = (dependencyId: string) => {
-		const relativeId = path.relative(config.root, dependencyId);
-		return JSON.stringify(relativeId || path.basename(dependencyId));
-	};
+	/*
+	 * Track active loading edges for cycle detection.
+	 *
+	 * When module A composes from B, context.load(B) triggers B's transform.
+	 * If B composes from A, context.load(A) deadlocks because A's transform
+	 * is suspended waiting for B. We detect this by tracking A→B as an active
+	 * edge and checking for cycles before each load.
+	 */
+	const activeEdges = new Map<string, Set<string>>();
 
-	const addActiveDependency = (
-		fromId: string,
-		dependencyId: string,
-	) => {
-		let dependencies = activeDependencies.get(fromId);
-		if (!dependencies) {
-			dependencies = new Map();
-			activeDependencies.set(fromId, dependencies);
-		}
-
-		dependencies.set(
-			dependencyId,
-			(dependencies.get(dependencyId) ?? 0) + 1,
-		);
-	};
-
-	const removeActiveDependency = (
-		fromId: string,
-		dependencyId: string,
-	) => {
-		const dependencies = activeDependencies.get(fromId);
-		if (!dependencies) {
-			return;
-		}
-
-		const nextCount = (dependencies.get(dependencyId) ?? 0) - 1;
-		if (nextCount > 0) {
-			dependencies.set(dependencyId, nextCount);
-			return;
-		}
-
-		dependencies.delete(dependencyId);
-		if (dependencies.size === 0) {
-			activeDependencies.delete(fromId);
-		}
-	};
-
-	const findDependencyPath = (
+	const findCyclePath = (
 		fromId: string,
 		targetId: string,
 		visited = new Set<string>(),
@@ -128,35 +95,23 @@ export const cssModules = (
 		if (fromId === targetId) {
 			return [fromId];
 		}
-
 		if (visited.has(fromId)) {
 			return;
 		}
 		visited.add(fromId);
 
-		const dependencies = activeDependencies.get(fromId);
+		const dependencies = activeEdges.get(fromId);
 		if (!dependencies) {
 			return;
 		}
 
-		for (const [dependencyId, count] of dependencies) {
-			if (count === 0) {
-				continue;
-			}
-
-			const dependencyPath = findDependencyPath(dependencyId, targetId, visited);
-			if (dependencyPath) {
-				return [
-					fromId,
-					...dependencyPath,
-				];
+		for (const dependencyId of dependencies) {
+			const cyclePath = findCyclePath(dependencyId, targetId, visited);
+			if (cyclePath) {
+				return [fromId, ...cyclePath];
 			}
 		}
 	};
-
-	const formatCycleError = (cyclePath: string[]) => new Error(
-		`Circular CSS Module dependency: ${cyclePath.map(formatDependencyId).join(' -> ')}`,
-	);
 
 	const loadExports = async (
 		context: TransformPluginContext,
@@ -170,15 +125,25 @@ export const cssModules = (
 
 		const importerId = cleanUrl(fromId);
 		const dependencyId = cleanUrl(resolved.id);
-		const dependencyPath = findDependencyPath(dependencyId, importerId);
-		if (dependencyPath) {
-			throw formatCycleError([
-				...dependencyPath,
-				dependencyId,
-			]);
+
+		const cyclePath = findCyclePath(dependencyId, importerId);
+		if (cyclePath) {
+			const formatId = (id: string) => {
+				const relativeId = path.relative(config.root, id);
+				return JSON.stringify(relativeId || path.basename(id));
+			};
+			throw new Error(
+				`Circular CSS Module dependency: ${[...cyclePath, dependencyId].map(formatId).join(' -> ')}`,
+			);
 		}
 
-		addActiveDependency(importerId, dependencyId);
+		let dependencies = activeEdges.get(importerId);
+		if (!dependencies) {
+			dependencies = new Set();
+			activeEdges.set(importerId, dependencies);
+		}
+		dependencies.add(dependencyId);
+
 		try {
 			const loaded = await context.load({
 				id: resolved.id,
@@ -186,7 +151,10 @@ export const cssModules = (
 			const pluginMeta = loaded.meta[pluginName] as PluginMeta;
 			return pluginMeta.exports;
 		} finally {
-			removeActiveDependency(importerId, dependencyId);
+			dependencies.delete(dependencyId);
+			if (dependencies.size === 0) {
+				activeEdges.delete(importerId);
+			}
 		}
 	};
 

--- a/tests/specs/patched/lightningcss.spec.ts
+++ b/tests/specs/patched/lightningcss.spec.ts
@@ -681,6 +681,37 @@ describe('LightningCSS', () => {
 		expect(css).toMatch('style.module.css?some-query');
 	});
 
+	test('cyclic cross-file composes throws a targeted error', async () => {
+		await using fixture = await createFixture({
+			'index.js': outdent`
+			export * from './a.module.css';
+			export { default } from './a.module.css';
+			`,
+
+			'a.module.css': outdent`
+			.a {
+				composes: b from './b.module.css';
+			}
+			`,
+
+			'b.module.css': outdent`
+			.b {
+				composes: a from './a.module.css';
+			}
+			`,
+		});
+
+		await expect(() => viteBuild(fixture.path, {
+			logLevel: 'silent',
+			plugins: [
+				patchCssModules(),
+			],
+			css: {
+				transformer: 'lightningcss',
+			},
+		})).rejects.toThrow('Circular CSS Module dependency');
+	});
+
 	test('hmr', async () => {
 		await using fixture = await createFixture(fixtures.viteDev);
 

--- a/tests/specs/patched/postcss.spec.ts
+++ b/tests/specs/patched/postcss.spec.ts
@@ -758,6 +758,34 @@ describe('PostCSS', () => {
 			})).rejects.toThrow('Cannot resolve "non-existent" from "./utils.css"');
 		});
 
+		test('cyclic cross-file composes throws a targeted error', async () => {
+			await using fixture = await createFixture({
+				'index.js': outdent`
+				export * from './a.module.css';
+				export { default } from './a.module.css';
+				`,
+
+				'a.module.css': outdent`
+				.a {
+					composes: b from './b.module.css';
+				}
+				`,
+
+				'b.module.css': outdent`
+				.b {
+					composes: a from './a.module.css';
+				}
+				`,
+			});
+
+			await expect(() => viteBuild(fixture.path, {
+				logLevel: 'silent',
+				plugins: [
+					patchCssModules(),
+				],
+			})).rejects.toThrow('Circular CSS Module dependency');
+		});
+
 		test('exporting a non-safe class name via esm doesnt throw', async () => {
 			await using fixture = await createFixture(fixtures.moduleNamespace);
 

--- a/tests/specs/patched/postcss.spec.ts
+++ b/tests/specs/patched/postcss.spec.ts
@@ -786,6 +786,38 @@ describe('PostCSS', () => {
 			})).rejects.toThrow('Circular CSS Module dependency');
 		});
 
+		test('cyclic cross-file @value throws a targeted error', async () => {
+			await using fixture = await createFixture({
+				'index.js': outdent`
+				export * from './a.module.css';
+				export { default } from './a.module.css';
+				`,
+
+				'a.module.css': outdent`
+				@value accent from './b.module.css';
+
+				.a {
+					color: accent;
+				}
+				`,
+
+				'b.module.css': outdent`
+				@value accent from './a.module.css';
+
+				.b {
+					color: accent;
+				}
+				`,
+			});
+
+			await expect(() => viteBuild(fixture.path, {
+				logLevel: 'silent',
+				plugins: [
+					patchCssModules(),
+				],
+			})).rejects.toThrow('Circular CSS Module dependency');
+		});
+
 		test('exporting a non-safe class name via esm doesnt throw', async () => {
 			await using fixture = await createFixture(fixtures.moduleNamespace);
 

--- a/tests/specs/reproductions.spec.ts
+++ b/tests/specs/reproductions.spec.ts
@@ -4,6 +4,7 @@ import { createFixture } from 'fs-fixture';
 import { describe, test, expect } from 'manten';
 import type { CssSyntaxError } from 'postcss';
 import vitePluginVue from '@vitejs/plugin-vue';
+import spawn from 'nano-spawn';
 import { base64Module } from '../utils/base64-module.ts';
 import * as fixtures from '../fixtures.ts';
 import { viteBuild, getViteDevCode, viteDevBrowser } from '../utils/vite.ts';
@@ -553,4 +554,59 @@ describe('reproductions', () => {
 			);
 		}, 10_000);
 	});
+
+	/*
+	 * Vanilla Vite (without patchCssModules) crashes on cyclic composes.
+	 * postcss-modules' FileSystemLoader throws an uncaught error during
+	 * circular dependency resolution that kills the process. There's no
+	 * graceful error — the build crashes with an internal postcss-modules
+	 * error.
+	 *
+	 * This documents the upstream behavior that patchCssModules fixes with
+	 * explicit cycle detection (throwing a descriptive error instead).
+	 *
+	 * Must run in a subprocess because the error is uncatchable in-process
+	 * (it's an unhandled exception from postcss-modules, not a rejected
+	 * promise from Vite's build API).
+	 */
+	test('cyclic composes crashes vanilla Vite', async () => {
+		await using fixture = await createFixture({
+			'index.js': `export * from './a.module.css';`,
+
+			'a.module.css': `.a {
+	composes: b from './b.module.css';
+}`,
+
+			'b.module.css': `.b {
+	composes: a from './a.module.css';
+}`,
+		});
+
+		try {
+			await spawn(process.execPath, [
+				'--input-type=module',
+				'-e',
+				`
+import { build } from 'vite';
+await build({
+	root: ${JSON.stringify(fixture.path)},
+	configFile: false,
+	logLevel: 'silent',
+	build: {
+		write: false,
+		rollupOptions: { input: ${JSON.stringify(path.join(fixture.path, 'index.js'))} },
+	},
+});
+`,
+			], {
+				timeout: 8000,
+			});
+
+			// If it somehow succeeds, fail the test
+			expect.unreachable('Expected build to crash');
+		} catch (error) {
+			// Non-zero exit code — the process crashed
+			expect((error as { exitCode?: number }).exitCode).not.toBe(0);
+		}
+	}, 10_000);
 });

--- a/tests/specs/reproductions.spec.ts
+++ b/tests/specs/reproductions.spec.ts
@@ -585,11 +585,10 @@ describe('reproductions', () => {
 }`,
 		});
 
-		try {
-			await execFileAsync(process.execPath, [
-				'--input-type=module',
-				'-e',
-				`import { build } from 'vite';
+		const result = await execFileAsync(process.execPath, [
+			'--input-type=module',
+			'-e',
+			`import { build } from 'vite';
 await build({
 	root: ${JSON.stringify(fixture.path)},
 	configFile: false,
@@ -599,15 +598,13 @@ await build({
 		rollupOptions: { input: ${JSON.stringify(path.join(fixture.path, 'index.js'))} },
 	},
 });`,
-			], {
-				timeout: 8000,
-			});
+		], {
+			timeout: 8000,
+		}).then(
+			() => 'success' as const,
+			() => 'crash' as const,
+		);
 
-			// If it somehow succeeds, fail the test
-			throw new Error('Expected build to crash');
-		} catch (error) {
-			// Non-zero exit code — the process crashed
-			expect((error as { code?: number }).code).not.toBe(0);
-		}
+		expect(result).toBe('crash');
 	}, 10_000);
 });

--- a/tests/specs/reproductions.spec.ts
+++ b/tests/specs/reproductions.spec.ts
@@ -1,14 +1,17 @@
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { createFixture } from 'fs-fixture';
 import { describe, test, expect } from 'manten';
 import type { CssSyntaxError } from 'postcss';
 import vitePluginVue from '@vitejs/plugin-vue';
-import spawn from 'nano-spawn';
 import { base64Module } from '../utils/base64-module.ts';
 import * as fixtures from '../fixtures.ts';
 import { viteBuild, getViteDevCode, viteDevBrowser } from '../utils/vite.ts';
 import { getCssSourceMaps } from '../utils/get-css-source-maps.ts';
+
+const execFileAsync = promisify(execFile);
 
 describe('reproductions', () => {
 	describe('postcss (no config)', () => {
@@ -571,7 +574,7 @@ describe('reproductions', () => {
 	 */
 	test('cyclic composes crashes vanilla Vite', async () => {
 		await using fixture = await createFixture({
-			'index.js': `export * from './a.module.css';`,
+			'index.js': 'export * from \'./a.module.css\';',
 
 			'a.module.css': `.a {
 	composes: b from './b.module.css';
@@ -583,11 +586,10 @@ describe('reproductions', () => {
 		});
 
 		try {
-			await spawn(process.execPath, [
+			await execFileAsync(process.execPath, [
 				'--input-type=module',
 				'-e',
-				`
-import { build } from 'vite';
+				`import { build } from 'vite';
 await build({
 	root: ${JSON.stringify(fixture.path)},
 	configFile: false,
@@ -596,8 +598,7 @@ await build({
 		write: false,
 		rollupOptions: { input: ${JSON.stringify(path.join(fixture.path, 'index.js'))} },
 	},
-});
-`,
+});`,
 			], {
 				timeout: 8000,
 			});
@@ -606,7 +607,7 @@ await build({
 			expect.unreachable('Expected build to crash');
 		} catch (error) {
 			// Non-zero exit code — the process crashed
-			expect((error as { exitCode?: number }).exitCode).not.toBe(0);
+			expect((error as { code?: number }).code).not.toBe(0);
 		}
 	}, 10_000);
 });

--- a/tests/specs/reproductions.spec.ts
+++ b/tests/specs/reproductions.spec.ts
@@ -604,7 +604,7 @@ await build({
 			});
 
 			// If it somehow succeeds, fail the test
-			expect.unreachable('Expected build to crash');
+			throw new Error('Expected build to crash');
 		} catch (error) {
 			// Non-zero exit code — the process crashed
 			expect((error as { code?: number }).code).not.toBe(0);

--- a/tests/specs/reproductions.spec.ts
+++ b/tests/specs/reproductions.spec.ts
@@ -1,17 +1,14 @@
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import { createFixture } from 'fs-fixture';
 import { describe, test, expect } from 'manten';
 import type { CssSyntaxError } from 'postcss';
 import vitePluginVue from '@vitejs/plugin-vue';
+import spawn from 'nano-spawn';
 import { base64Module } from '../utils/base64-module.ts';
 import * as fixtures from '../fixtures.ts';
 import { viteBuild, getViteDevCode, viteDevBrowser } from '../utils/vite.ts';
 import { getCssSourceMaps } from '../utils/get-css-source-maps.ts';
-
-const execFileAsync = promisify(execFile);
 
 describe('reproductions', () => {
 	describe('postcss (no config)', () => {
@@ -585,7 +582,7 @@ describe('reproductions', () => {
 }`,
 		});
 
-		const result = await execFileAsync(process.execPath, [
+		const result = await spawn(process.execPath, [
 			'--input-type=module',
 			'-e',
 			`import { build } from 'vite';


### PR DESCRIPTION
## Problem

When two CSS Modules compose from each other (`a.module.css` composes from `b.module.css` and vice versa), Vite's internal `postcss-modules` triggers a deadlock that crashes the build with an unhelpful internal error (`The returned path from the "fileResolve" option must be absolute`). There's no cycle detection — the process just dies.

## Changes

- Detect circular `composes` dependencies before they deadlock by tracking active loading edges in the module graph. When a cycle is found, throw a descriptive error: `Circular CSS Module dependency: "a.module.css" -> "b.module.css" -> "a.module.css"`
- Add cycle detection tests for both PostCSS and LightningCSS code paths
- Add a reproduction test documenting vanilla Vite's crash behavior (runs in a subprocess since the error is uncatchable in-process)
- Add `nano-spawn` dev dependency for subprocess test
- Document the fix in README FAQ