### PR TITLE
fix: Windows support — normalize path separators, add Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: Test
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -30,6 +30,30 @@ jobs:
 
       - name: Typecheck
         run: pnpm type-check
+
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          run_install: true
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,10 @@ jobs:
 
       - name: Test
         run: pnpm test:vite7
+        env:
+          # fs-fixture defaults to os.tmpdir() which is on C: drive,
+          # but the repo checkout is on D: drive. path.relative() cannot
+          # compute relative paths across drives, breaking CSS module
+          # hash generation. Setting TEMP to the same drive fixes this.
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,8 @@ jobs:
 
   test:
     name: Test
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -60,3 +55,30 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  test-windows:
+    name: Test (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          run_install: true
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test:vite7
+        env:
+          TESTONLY: devSourcemap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,31 +6,6 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Use Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: .nvmrc
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-        with:
-          run_install: true
-
-      - name: Lint
-        run: pnpm lint
-
-      - name: Typecheck
-        run: pnpm type-check
-
   test:
     name: Test
     runs-on: ${{ matrix.os }}
@@ -54,6 +29,14 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           run_install: true
+
+      - name: Lint
+        if: matrix.os == 'ubuntu-latest'
+        run: pnpm lint
+
+      - name: Typecheck
+        if: matrix.os == 'ubuntu-latest'
+        run: pnpm type-check
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Setup Dev Drive
-        if: runner.os == 'Windows'
-        uses: samypr100/setup-dev-drive@cf663fdf88945e3faaa980ec525b5bc2350fbf9d # v3
-        with:
-          env-mapping: |
-            PNPM_HOME,{{ DEV_DRIVE }}/.pnpm
-            PNPM_STORE_DIR,{{ DEV_DRIVE }}/.pnpm-store
-
       - name: Use Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,9 +79,9 @@ jobs:
         run: pnpm build
 
       - name: Test
-        run: pnpm test:vite7
+        run: pnpm test
         env:
-          # fs-fixture defaults to os.tmpdir() which is on C: drive,
+          # fs-fixture defaults to os.tmpdir() (C: drive on GH runners),
           # but the repo checkout is on D: drive. path.relative() cannot
           # compute relative paths across drives, breaking CSS module
           # hash generation. Setting TEMP to the same drive fixes this.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,33 +33,13 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Use Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: .nvmrc
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-        with:
-          run_install: true
-
-      - name: Build
-        run: pnpm build
-
-      - name: Test
-        run: pnpm test
-
-  test-windows:
-    name: Test (Windows)
-    runs-on: windows-latest
-    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Setup Dev Drive
+        if: runner.os == 'Windows'
+        uses: samypr100/setup-dev-drive@cf663fdf88945e3faaa980ec525b5bc2350fbf9d # v3
+        with:
+          env-mapping: |
+            PNPM_HOME,{{ DEV_DRIVE }}/.pnpm
+            PNPM_STORE_DIR,{{ DEV_DRIVE }}/.pnpm-store
+
       - name: Use Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,5 +80,3 @@ jobs:
 
       - name: Test
         run: pnpm test:vite7
-        env:
-          TESTONLY: devSourcemap

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -144,7 +144,7 @@ export const cssModules = (
 		const cyclePath = findCyclePath(dependencyId, importerId);
 		if (cyclePath) {
 			const formatId = (id: string) => {
-				const relativeId = path.relative(config.root, id);
+				const relativeId = path.relative(config.root, id).replaceAll('\\', '/');
 				return JSON.stringify(relativeId || path.basename(id));
 			};
 			throw new Error(
@@ -245,7 +245,7 @@ export const cssModules = (
 					 * Relative path from project root to get stable CSS modules hash
 					 * https://github.com/vitejs/vite/blob/57463fc53fedc8f29e05ef3726f156a6daf65a94/packages/vite/src/node/plugins/css.ts#L2690
 					 */
-					cleanUrl(path.relative(config.root, id)),
+					cleanUrl(path.relative(config.root, id)).replaceAll('\\', '/'),
 					isLightningCss ? lightningCssOptions : cssModuleConfig,
 					devSourcemap,
 				);

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -14,7 +14,9 @@ import type { PluginMeta, ExportMode } from './types.js';
 import { supportsArbitraryModuleNamespace } from './supports-arbitrary-module-namespace.js';
 import type { transform as PostcssTransform } from './transformers/postcss/index.js';
 import type { transform as LightningcssTransform } from './transformers/lightningcss.js';
-import { getCssModuleUrl, cleanUrl, cssModuleRE, slash } from './url-utils.js';
+import {
+	getCssModuleUrl, cleanUrl, cssModuleRE, slash,
+} from './url-utils.js';
 
 export const pluginName = 'vite:css-modules';
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -14,7 +14,7 @@ import type { PluginMeta, ExportMode } from './types.js';
 import { supportsArbitraryModuleNamespace } from './supports-arbitrary-module-namespace.js';
 import type { transform as PostcssTransform } from './transformers/postcss/index.js';
 import type { transform as LightningcssTransform } from './transformers/lightningcss.js';
-import { getCssModuleUrl, cleanUrl, cssModuleRE } from './url-utils.js';
+import { getCssModuleUrl, cleanUrl, cssModuleRE, slash } from './url-utils.js';
 
 export const pluginName = 'vite:css-modules';
 
@@ -144,7 +144,7 @@ export const cssModules = (
 		const cyclePath = findCyclePath(dependencyId, importerId);
 		if (cyclePath) {
 			const formatId = (id: string) => {
-				const relativeId = path.relative(config.root, id).replaceAll('\\', '/');
+				const relativeId = slash(path.relative(config.root, id));
 				return JSON.stringify(relativeId || path.basename(id));
 			};
 			throw new Error(
@@ -245,7 +245,7 @@ export const cssModules = (
 					 * Relative path from project root to get stable CSS modules hash
 					 * https://github.com/vitejs/vite/blob/57463fc53fedc8f29e05ef3726f156a6daf65a94/packages/vite/src/node/plugins/css.ts#L2690
 					 */
-					cleanUrl(path.relative(config.root, id)).replaceAll('\\', '/'),
+					slash(cleanUrl(path.relative(config.root, id))),
 					isLightningCss ? lightningCssOptions : cssModuleConfig,
 					devSourcemap,
 				);

--- a/src/plugin/url-utils.ts
+++ b/src/plugin/url-utils.ts
@@ -8,6 +8,8 @@ export const cleanUrl = (url: string) => (
 		: url
 );
 
+export const slash = (filePath: string) => filePath.replaceAll('\\', '/');
+
 export const getCssModuleUrl = (url: string) => {
 	if (cssModuleRE.test(url)) {
 		return url;

--- a/tests/utils/vite.ts
+++ b/tests/utils/vite.ts
@@ -137,8 +137,8 @@ export const getViteDevCode = async (
 ) => await viteServe(
 	fixturePath,
 	config,
-	url => {
-		const posixPath = fixturePath.replace(/\\/g, '/');
+	(url) => {
+		const posixPath = fixturePath.replaceAll('\\', '/');
 		return bundleHttpJs(url, `@fs${posixPath.startsWith('/') ? '' : '/'}${posixPath}/index.js`);
 	},
 );

--- a/tests/utils/vite.ts
+++ b/tests/utils/vite.ts
@@ -5,6 +5,7 @@ import {
 } from 'vite';
 import { rollup } from 'rollup';
 import { chromium, type Page } from 'playwright-chromium';
+import { slash } from '../../src/plugin/url-utils.ts';
 
 export const viteBuild = async (
 	fixturePath: string,
@@ -138,7 +139,7 @@ export const getViteDevCode = async (
 	fixturePath,
 	config,
 	(url) => {
-		const posixPath = fixturePath.replaceAll('\\', '/');
+		const posixPath = slash(fixturePath);
 		return bundleHttpJs(url, `@fs${posixPath.startsWith('/') ? '' : '/'}${posixPath}/index.js`);
 	},
 );

--- a/tests/utils/vite.ts
+++ b/tests/utils/vite.ts
@@ -86,7 +86,7 @@ const bundleHttpJs = async (
 					let retry = 5;
 					while (retry > 0) {
 						try {
-							const response = await fetch(path.join(baseUrl, id));
+							const response = await fetch(new URL(id, baseUrl));
 							return await response.text();
 						} catch (error) {
 							if (retry === 0) {
@@ -137,7 +137,10 @@ export const getViteDevCode = async (
 ) => await viteServe(
 	fixturePath,
 	config,
-	url => bundleHttpJs(url, `@fs${fixturePath}/index.js`),
+	url => {
+		const posixPath = fixturePath.replace(/\\/g, '/');
+		return bundleHttpJs(url, `@fs${posixPath.startsWith('/') ? '' : '/'}${posixPath}/index.js`);
+	},
 );
 
 export const viteDevBrowser = async (


### PR DESCRIPTION
## Summary
- Fix cross-platform path separator issues in plugin source
- Add Windows to CI test matrix
- Fix Windows-specific issues in test utilities

## Changes

### Plugin fix (`src/plugin/index.ts`, `src/plugin/url-utils.ts`)
- Add `slash()` utility to normalize backslashes to forward slashes
- Normalize `path.relative()` output at two call sites:
  - **Line 148**: error messages for cyclic dependency detection
  - **Line 250**: CSS module hash input — without this, the same CSS Module produces different class name hashes on Windows vs Linux

### Test utility fix (`tests/utils/vite.ts`)
- **`@fs` path**: `@fs${fixturePath}/index.js` broke on Windows because Windows absolute paths start with a drive letter (`C:\`), not `/`. Fixed by normalizing to forward slashes and ensuring a `/` separator after `@fs`
- **URL construction**: Replaced `path.join(baseUrl, id)` with `new URL(id, baseUrl)` — `path.join` uses OS-native separators, producing backslash URLs on Windows

### CI (`test.yml`)
- Add `windows-latest` to test matrix with `fail-fast: false`
- Lint/typecheck only on Linux (platform-independent)
- Set `TEMP`/`TMP` to `runner.temp` on Windows so test fixtures are on the same drive as the checkout (GitHub Windows runners use `C:` for temp, `D:` for checkout — `path.relative()` can't compute relative paths across drives)