### PR TITLE
Show the plugin in Vite Plugin Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"keywords": [
 		"vite",
 		"plugin",
+		"vite-plugin",
 		"css modules",
 		"patch"
 	],


### PR DESCRIPTION
Vite/voidzero recently announced Vite Plugin Registry: https://registry.vite.dev/plugins

This change makes it possible for their scanner to find the plugin and add it to the registry.

Added the keyword based on their guide: https://registry.vite.dev/guide/