### PR TITLE
Generate .d.ts files with configureServer watcher in development

### DIFF
--- a/src/cli/load-css-module.ts
+++ b/src/cli/load-css-module.ts
@@ -50,7 +50,8 @@ export const createCssModuleLoader = (
 		);
 
 		const id = cleanUrl(path.relative(context.resolvedConfig.root, filePath));
-		const cssModule = context.resolvedConfig.css.transformer === 'lightningcss'
+		const transformer = context.originalTransformer ?? context.resolvedConfig.css.transformer;
+		const cssModule = transformer === 'lightningcss'
 			? lightningcssTransform(
 				processed.code,
 				id,
@@ -131,5 +132,9 @@ export const createCssModuleLoader = (
 		return cached;
 	};
 
-	return loadCssModule;
+	const invalidate = (filePath: string) => {
+		cache.delete(filePath);
+	};
+
+	return Object.assign(loadCssModule, { invalidate });
 };

--- a/src/cli/project-context.ts
+++ b/src/cli/project-context.ts
@@ -28,6 +28,8 @@ export type ProjectContext = {
 	declarationMap: boolean;
 	exportMode: ExportMode;
 	resolvedConfig: ResolvedConfig;
+	originalTransformer?: string;
+	allowArbitraryNamedExports?: boolean;
 };
 
 type ProjectContextOptions = {

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -1,11 +1,21 @@
 import path from 'path';
-import type { Plugin, ServerHook } from 'vite';
+import fs from 'node:fs/promises';
+import type {
+	Plugin, ServerHook, CSSModulesOptions,
+} from 'vite';
 import type {
 	SourceMap, ObjectHook, TransformPluginContext, TransformResult,
 } from 'rollup';
+import { getTsconfig } from 'get-tsconfig';
+import { glob } from 'tinyglobby';
 import { cssModules, type PatchConfig } from './plugin/index.js';
 import { cssModuleRE } from './plugin/url-utils.js';
-import type { PluginMeta } from './plugin/types.js';
+import { generateTypes } from './plugin/generate-types.js';
+import { writeFileIfChanged } from './write-file-if-changed.js';
+import { createCssModuleLoader } from './cli/load-css-module.js';
+import type { ProjectContext } from './cli/project-context.js';
+import { supportsArbitraryModuleNamespace } from './plugin/supports-arbitrary-module-namespace.js';
+import type { ExportMode, PluginMeta } from './plugin/types.js';
 
 const patchConfigSymbol = Symbol('patchConfig');
 
@@ -222,6 +232,8 @@ export const patchCssModules = (
 	 */
 	const originalCssCache = new Map<string, string>();
 
+	let serverProjectContext: ProjectContext | undefined;
+
 	const plugin: Plugin & { [patchConfigSymbol]?: PatchConfig } = {
 		name: 'patch-css-modules',
 		enforce: 'pre',
@@ -249,6 +261,24 @@ export const patchCssModules = (
 
 			if (isCssModulesDisabled) {
 				return;
+			}
+
+			if (patchConfig?.generateSourceTypes && config.command === 'serve') {
+				const cssModulesConfig: CSSModulesOptions = { ...cssConfig.modules };
+				const originalTransformer = cssConfig.transformer;
+				const exportMode: ExportMode = patchConfig.exportMode ?? 'both';
+				const declarationMap = patchConfig.declarationMap
+					?? getTsconfig(config.root)?.config.compilerOptions?.declarationMap
+					?? false;
+
+				serverProjectContext = {
+					cssModulesConfig,
+					declarationMap,
+					exportMode,
+					resolvedConfig: config,
+					originalTransformer,
+					allowArbitraryNamedExports: supportsArbitraryModuleNamespace(config),
+				};
 			}
 
 			// Disable CSS Modules in Vite in favor of our plugin
@@ -296,6 +326,55 @@ export const patchCssModules = (
 
 			// Enable HMR by making CSS Modules not self accept
 			supportCssModulesHMR(config.plugins);
+		},
+
+		configureServer(server) {
+			if (!serverProjectContext) {
+				return;
+			}
+
+			const projectContext = serverProjectContext;
+			const loader = createCssModuleLoader(projectContext);
+
+			const generateForFile = async (file: string) => {
+				if (!cssModuleRE.test(file)) {
+					return;
+				}
+				try {
+					loader.invalidate(file);
+					const { exports, sourceMapOptions } = await loader(file);
+					const dts = generateTypes(
+						exports,
+						projectContext.exportMode,
+						projectContext.allowArbitraryNamedExports ?? false,
+						sourceMapOptions,
+					);
+					await writeFileIfChanged(`${file}.d.ts`, dts);
+				} catch (error) {
+					server.config.logger.error(
+						`[vite-css-modules] Failed to generate types for ${file}: ${(error as Error).message}`,
+					);
+				}
+			};
+
+			return async () => {
+				const files = await glob('**/*.module.{css,scss,sass,less,styl,stylus,pcss,postcss,sss}', {
+					cwd: server.config.root,
+					absolute: true,
+					ignore: ['**/node_modules/**'],
+				});
+				await Promise.all(files.map(generateForFile));
+
+				server.watcher.on('change', generateForFile);
+				server.watcher.on('add', generateForFile);
+				server.watcher.on('unlink', async (file) => {
+					if (!cssModuleRE.test(file)) {
+						return;
+					}
+					loader.invalidate(file);
+					await fs.unlink(`${file}.d.ts`).catch(() => {});
+				});
+			};
 		},
 	};
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -419,7 +419,7 @@ export const cssModules = (
 					allowArbitraryNamedExports,
 				);
 
-				if (patchConfig?.generateSourceTypes) {
+				if (patchConfig?.generateSourceTypes && config.command === 'build') {
 					const filePath = id.split('?', 2)[0];
 
 					// Only generate types for importable module files

--- a/tests/specs/patched/postcss.spec.ts
+++ b/tests/specs/patched/postcss.spec.ts
@@ -1,5 +1,5 @@
 import { setTimeout } from 'node:timers/promises';
-import { readdir } from 'node:fs/promises';
+import { readdir, unlink } from 'node:fs/promises';
 import path from 'node:path';
 import { createFixture } from 'fs-fixture';
 import {
@@ -1064,6 +1064,104 @@ describe('PostCSS', () => {
 
 				`,
 			);
+		});
+
+		test('dev server generates .d.ts on startup', async () => {
+			await using fixture = await createFixture({
+				...fixtures.reservedKeywords,
+				node_modules: ({ symlink }) => symlink(path.resolve('node_modules')),
+			});
+
+			const server = await vite.createServer({
+				root: fixture.path,
+				configFile: false,
+				envFile: false,
+				logLevel: 'error',
+				plugins: [
+					patchCssModules({
+						generateSourceTypes: true,
+					}),
+				],
+			});
+			try {
+				await server.listen();
+				await setTimeout(2000);
+				const dts = await fixture.readFile('style.module.css.d.ts', 'utf8');
+				expect(dts).toMatch('declare const _import: string;');
+				expect(dts).toMatch('declare const _export: string;');
+				expect(dts).toMatch('declare const _default: string;');
+			} finally {
+				await server.close();
+			}
+		});
+
+		test('dev server regenerates .d.ts on file change', async () => {
+			await using fixture = await createFixture({
+				'index.js': 'import "./style.module.css";',
+				'style.module.css': '.button { color: red; }',
+				node_modules: ({ symlink }) => symlink(path.resolve('node_modules')),
+			});
+
+			const server = await vite.createServer({
+				root: fixture.path,
+				configFile: false,
+				envFile: false,
+				logLevel: 'error',
+				plugins: [
+					patchCssModules({
+						generateSourceTypes: true,
+					}),
+				],
+			});
+			try {
+				await server.listen();
+				await setTimeout(2000);
+				const dtsBefore = await fixture.readFile('style.module.css.d.ts', 'utf8');
+				expect(dtsBefore).toMatch('declare const button: string;');
+				expect(dtsBefore).not.toMatch('declare const heading: string;');
+
+				await fixture.writeFile('style.module.css', '.heading { color: blue; }');
+				await setTimeout(2000);
+				const dtsAfter = await fixture.readFile('style.module.css.d.ts', 'utf8');
+				expect(dtsAfter).toMatch('declare const heading: string;');
+				expect(dtsAfter).not.toMatch('declare const button: string;');
+			} finally {
+				await server.close();
+			}
+		});
+
+		test('dev server deletes .d.ts when css module is deleted', async () => {
+			await using fixture = await createFixture({
+				'index.js': 'import "./style.module.css";',
+				'style.module.css': '.button { color: red; }',
+				node_modules: ({ symlink }) => symlink(path.resolve('node_modules')),
+			});
+
+			const server = await vite.createServer({
+				root: fixture.path,
+				configFile: false,
+				envFile: false,
+				logLevel: 'error',
+				plugins: [
+					patchCssModules({
+						generateSourceTypes: true,
+					}),
+				],
+			});
+			try {
+				await server.listen();
+				await setTimeout(2000);
+				const dts = await fixture.readFile('style.module.css.d.ts', 'utf8');
+				expect(dts).toMatch('declare const button: string;');
+
+				await unlink(path.join(fixture.path, 'style.module.css'));
+				await setTimeout(2000);
+				const files = await readdir(fixture.path);
+				expect(files).not.toContain('style.module.css');
+				expect(files).not.toContain('style.module.css.d.ts');
+			} finally {
+				await server.close();
+			}
 		});
 
 		test('updates generated type files when resolved Vite config changes', async () => {


### PR DESCRIPTION
Closes #106

## Problem
`.d.ts` generation via the transform hook only fires when the browser requests a CSS module. Types aren't available until a page that imports the module is visited.

## Changes
Move `.d.ts` generation in dev mode to a configureServer hook. Build mode is unchanged.

## How it works
In `configResolved`, capture the CSS modules config before Vite's config is mutated (transformer, modules options, etc.) and assemble a `ProjectContext`
In `configureServer`, create a `CssModuleLoader` (reusing the CLI's existing `createCssModuleLoader`) and:

1. On startup: glob for all files and generate `.d.ts` for each
2. After initial scan completes, register watchers:
   - On change/add: invalidate the loader cache and regenerate
   - On unlink: invalidate the loader cache and delete the `.d.ts`

In the transform hook, skip `.d.ts` generation when `config.command === 'serve'` (the watcher handles it)

## Files changed
`src/patch.ts`
- Added configureServer hook with watcher, initial scan, and unlink cleanup.
- Capture original transformer and CSS modules config before config mutation.
- Computes `allowArbitraryNamedExports` from `supportsArbitraryModuleNamespace(config)` and passes it through the context.

`src/plugin/index.ts`
- Guard .d.ts generation with `config.command === 'build'` so it only runs during build

`src/cli/load-css-module.ts`
- Expose `invalidate(filePath)` method on the loader for cache invalidation on file change. 
- Use `context.originalTransformer` when available to pick the correct transformer after config mutation.

`src/cli/project-context.ts`
- Add optional `originalTransformer` and `allowArbitraryNamedExports` fields to ProjectContext type

## Tests added

- dev server generates `.d.ts` on startup — verifies initial scan produces types
- dev server regenerates `.d.ts` on file change — verifies watcher updates types on save
- dev server deletes `.d.ts` when css module is deleted — verifies unlink cleanup