### PR TITLE
feat: add watch flag to cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 	"dependencies": {
 		"@jridgewell/remapping": "^2.3.5",
 		"@jridgewell/sourcemap-codec": "^1.5.5",
+		"@parcel/watcher": "^2.5.6",
 		"@rollup/pluginutils": "^5.3.0",
 		"cleye": "^2.2.1",
 		"css-class-positions": "^1.0.0",
@@ -71,6 +72,7 @@
 		"get-tsconfig": "^4.13.8",
 		"icss-utils": "^5.1.0",
 		"magic-string": "^0.30.21",
+		"picomatch": "^4.0.4",
 		"postcss-modules-extract-imports": "^3.1.0",
 		"postcss-modules-local-by-default": "^4.2.0",
 		"postcss-modules-scope": "^3.2.1",
@@ -92,6 +94,7 @@
 		"@types/icss-utils": "^5.1.2",
 		"@types/lodash.camelcase": "^4.3.9",
 		"@types/node": "^24.10.15",
+		"@types/picomatch": "^4.0.3",
 		"@types/postcss-modules-extract-imports": "^3.0.5",
 		"@types/postcss-modules-local-by-default": "^4.0.2",
 		"@types/postcss-modules-values": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.5.5
         version: 1.5.5
+      '@parcel/watcher':
+        specifier: ^2.5.6
+        version: 2.5.6
       '@rollup/pluginutils':
         specifier: ^5.3.0
         version: 5.3.0(rollup@4.60.2)
@@ -35,6 +38,9 @@ importers:
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
+      picomatch:
+        specifier: ^4.0.4
+        version: 4.0.4
       postcss-modules-extract-imports:
         specifier: ^3.1.0
         version: 3.1.0(postcss@8.5.10)
@@ -63,6 +69,9 @@ importers:
       '@types/node':
         specifier: ^24.10.15
         version: 24.10.15
+      '@types/picomatch':
+        specifier: ^4.0.3
+        version: 4.0.3
       '@types/postcss-modules-extract-imports':
         specifier: ^3.0.5
         version: 3.0.5
@@ -975,86 +984,92 @@ packages:
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
 
-  '@parcel/watcher-android-arm64@2.5.1':
-    resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [android]
 
-  '@parcel/watcher-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==}
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@parcel/watcher-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==}
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@parcel/watcher-freebsd-x64@2.5.1':
-    resolution: {integrity: sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==}
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  '@parcel/watcher-linux-arm-glibc@2.5.1':
-    resolution: {integrity: sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==}
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
-  '@parcel/watcher-linux-arm-musl@2.5.1':
-    resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
-  '@parcel/watcher-linux-arm64-glibc@2.5.1':
-    resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@parcel/watcher-linux-arm64-musl@2.5.1':
-    resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@parcel/watcher-linux-x64-glibc@2.5.1':
-    resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@parcel/watcher-linux-x64-musl@2.5.1':
-    resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@parcel/watcher-win32-arm64@2.5.1':
-    resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@parcel/watcher-win32-ia32@2.5.1':
-    resolution: {integrity: sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==}
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
     engines: {node: '>= 10.0.0'}
     cpu: [ia32]
     os: [win32]
 
-  '@parcel/watcher-win32-x64@2.5.1':
-    resolution: {integrity: sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==}
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [win32]
 
-  '@parcel/watcher@2.5.1':
-    resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
   '@pkgr/core@0.2.9':
@@ -1099,36 +1114,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
@@ -1244,66 +1265,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1382,6 +1416,9 @@ packages:
 
   '@types/node@24.10.15':
     resolution: {integrity: sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==}
+
+  '@types/picomatch@4.0.3':
+    resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
 
   '@types/postcss-modules-extract-imports@3.0.5':
     resolution: {integrity: sha512-l4nXU3x83qmQEu92yajJLdTqKZcZCZjb2U07HixV1twnLwLVg0BCDaKnjlbwLCth/YevMVzFdsBx/0iSbyVqsg==}
@@ -1505,41 +1542,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1844,11 +1889,6 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  detect-libc@1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2666,48 +2706,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3030,10 +3078,6 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -4296,66 +4340,65 @@ snapshots:
 
   '@oxc-project/types@0.115.0': {}
 
-  '@parcel/watcher-android-arm64@2.5.1':
+  '@parcel/watcher-android-arm64@2.5.6':
     optional: true
 
-  '@parcel/watcher-darwin-arm64@2.5.1':
+  '@parcel/watcher-darwin-arm64@2.5.6':
     optional: true
 
-  '@parcel/watcher-darwin-x64@2.5.1':
+  '@parcel/watcher-darwin-x64@2.5.6':
     optional: true
 
-  '@parcel/watcher-freebsd-x64@2.5.1':
+  '@parcel/watcher-freebsd-x64@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-arm-glibc@2.5.1':
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-arm-musl@2.5.1':
+  '@parcel/watcher-linux-arm-musl@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-arm64-glibc@2.5.1':
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-arm64-musl@2.5.1':
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-x64-glibc@2.5.1':
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
     optional: true
 
-  '@parcel/watcher-linux-x64-musl@2.5.1':
+  '@parcel/watcher-linux-x64-musl@2.5.6':
     optional: true
 
-  '@parcel/watcher-win32-arm64@2.5.1':
+  '@parcel/watcher-win32-arm64@2.5.6':
     optional: true
 
-  '@parcel/watcher-win32-ia32@2.5.1':
+  '@parcel/watcher-win32-ia32@2.5.6':
     optional: true
 
-  '@parcel/watcher-win32-x64@2.5.1':
+  '@parcel/watcher-win32-x64@2.5.6':
     optional: true
 
-  '@parcel/watcher@2.5.1':
+  '@parcel/watcher@2.5.6':
     dependencies:
-      detect-libc: 1.0.3
+      detect-libc: 2.1.2
       is-glob: 4.0.3
-      micromatch: 4.0.8
       node-addon-api: 7.1.1
+      picomatch: 4.0.4
     optionalDependencies:
-      '@parcel/watcher-android-arm64': 2.5.1
-      '@parcel/watcher-darwin-arm64': 2.5.1
-      '@parcel/watcher-darwin-x64': 2.5.1
-      '@parcel/watcher-freebsd-x64': 2.5.1
-      '@parcel/watcher-linux-arm-glibc': 2.5.1
-      '@parcel/watcher-linux-arm-musl': 2.5.1
-      '@parcel/watcher-linux-arm64-glibc': 2.5.1
-      '@parcel/watcher-linux-arm64-musl': 2.5.1
-      '@parcel/watcher-linux-x64-glibc': 2.5.1
-      '@parcel/watcher-linux-x64-musl': 2.5.1
-      '@parcel/watcher-win32-arm64': 2.5.1
-      '@parcel/watcher-win32-ia32': 2.5.1
-      '@parcel/watcher-win32-x64': 2.5.1
-    optional: true
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
 
   '@pkgr/core@0.2.9': {}
 
@@ -4421,10 +4464,10 @@ snapshots:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       is-reference: 1.2.1
       magic-string: 0.30.21
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.60.2
 
@@ -4458,7 +4501,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.60.2
 
@@ -4547,7 +4590,7 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -4591,6 +4634,8 @@ snapshots:
   '@types/node@24.10.15':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/picomatch@4.0.3': {}
 
   '@types/postcss-modules-extract-imports@3.0.5':
     dependencies:
@@ -5081,9 +5126,6 @@ snapshots:
   defu@6.1.4: {}
 
   dequal@2.0.3: {}
-
-  detect-libc@1.0.3:
-    optional: true
 
   detect-libc@2.1.2: {}
 
@@ -5648,10 +5690,6 @@ snapshots:
     dependencies:
       format: 0.2.2
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -6033,7 +6071,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jiti@2.6.1: {}
 
@@ -6599,8 +6637,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-addon-api@7.1.1:
-    optional: true
+  node-addon-api@7.1.1: {}
 
   node-releases@2.0.27: {}
 
@@ -6684,8 +6721,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 
@@ -6923,7 +6958,7 @@ snapshots:
       immutable: 5.1.4
       source-map-js: 1.2.1
     optionalDependencies:
-      '@parcel/watcher': 2.5.1
+      '@parcel/watcher': 2.5.6
 
   scslre@0.3.0:
     dependencies:
@@ -7107,7 +7142,7 @@ snapshots:
 
   ts-declaration-location@1.0.7(typescript@5.9.3):
     dependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       typescript: 5.9.3
 
   tslib@2.8.1:
@@ -7254,8 +7289,8 @@ snapshots:
   vite@6.4.1(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.20.6)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.60.2
       tinyglobby: 0.2.16
@@ -7271,8 +7306,8 @@ snapshots:
   vite@7.3.1(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.20.6)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.1
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.60.2
       tinyglobby: 0.2.16
@@ -7289,7 +7324,7 @@ snapshots:
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       postcss: 8.5.10
       rolldown: 1.0.0-rc.9
       tinyglobby: 0.2.16

--- a/src/cli/generate-declaration.ts
+++ b/src/cli/generate-declaration.ts
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+import path from 'node:path';
+import { generateTypes } from '../plugin/generate-types.js';
+import { writeFileIfChanged } from '../write-file-if-changed.js';
+import { slash } from '../plugin/url-utils.js';
+import type { createCssModuleLoader } from './load-css-module.js';
+import type { ProjectContext } from './project-context.js';
+
+export type CssModuleLoader = ReturnType<typeof createCssModuleLoader>;
+
+export const generateDeclarationForFile = async (
+	projectContext: ProjectContext,
+	loadCssModule: CssModuleLoader,
+	cwd: string,
+	filePath: string,
+	allowArbitraryNamedExports: boolean,
+	silent: boolean,
+	failOnError: boolean,
+): Promise<void> => {
+	const relativePath = slash(path.relative(cwd, filePath));
+	try {
+		const { exports, sourceMapOptions } = await loadCssModule(filePath);
+		const generatedDts = generateTypes(
+			exports,
+			projectContext.exportMode,
+			allowArbitraryNamedExports,
+			sourceMapOptions,
+		);
+
+		const dtsPath = `${filePath}.d.ts`;
+		await writeFileIfChanged(dtsPath, generatedDts);
+		if (!silent) {
+			console.log(`✓ ${relativePath}.d.ts`);
+		}
+	} catch (error) {
+		console.error(`✗ ${relativePath}`);
+		console.error(`  ${(error instanceof Error ? error.message : String(error))}`);
+		if (failOnError) {
+			process.exitCode = 1;
+		}
+	}
+};
+/* eslint-enable no-console */

--- a/src/cli/glob-scope.ts
+++ b/src/cli/glob-scope.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+
+export const defaultGlob = '**/*.module.{css,scss,sass}';
+
+export type GlobScope = {
+	globs: string[];
+	globCwd: string;
+};
+
+export const resolveGlobScope = (
+	inputGlobs: string[],
+	cwd: string,
+	root: string,
+): GlobScope => {
+	if (inputGlobs.length === 0) {
+		const rootRelative = path.relative(cwd, root);
+		if (rootRelative === '..' || rootRelative.startsWith(`..${path.sep}`) || path.isAbsolute(rootRelative)) {
+			throw new Error(`Resolved Vite root is outside the current working directory: ${root}\nPass explicit globs to control the search scope.`);
+		}
+
+		return {
+			globs: [defaultGlob],
+			globCwd: root,
+		};
+	}
+
+	return {
+		globs: inputGlobs,
+		globCwd: cwd,
+	};
+};

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,7 +44,9 @@ import {
 
 	const cwd = process.cwd();
 	const { globs: inputGlobs = [] } = argv._;
-	const { config, mode, silent, watch: watchMode } = argv.flags;
+	const {
+		config, mode, silent, watch: watchMode,
+	} = argv.flags;
 	const configPath = config
 		? path.resolve(config)
 		: await findViteConfigInDirectory(cwd);
@@ -58,7 +60,8 @@ import {
 		mode,
 	});
 	const { root } = projectContext.resolvedConfig;
-	const allowArbitraryNamedExports = supportsArbitraryModuleNamespace(projectContext.resolvedConfig);
+	const allowArbitraryNamedExports =
+		supportsArbitraryModuleNamespace(projectContext.resolvedConfig);
 
 	const { globs, globCwd } = resolveGlobScope(inputGlobs, cwd, root);
 
@@ -75,17 +78,15 @@ import {
 
 	const loadCssModule = createCssModuleLoader(projectContext);
 
-	await Promise.all(files.map(filePath =>
-		generateDeclarationForFile(
-			projectContext,
-			loadCssModule,
-			cwd,
-			filePath,
-			allowArbitraryNamedExports,
-			silent ?? false,
-			!watchMode,
-		),
-	));
+	await Promise.all(files.map(filePath => generateDeclarationForFile(
+		projectContext,
+		loadCssModule,
+		cwd,
+		filePath,
+		allowArbitraryNamedExports,
+		silent ?? false,
+		!watchMode,
+	)));
 
 	if (watchMode) {
 		const { runWatch } = await import('./watch.js');
@@ -101,7 +102,7 @@ import {
 		});
 
 		const shutdown = () => {
-			cleanup().then(() => process.exit());
+			cleanup().then(() => process.exit(0)).catch(() => {});
 		};
 		process.on('SIGINT', shutdown);
 		process.on('SIGTERM', shutdown);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,16 +2,14 @@
 import path from 'node:path';
 import { cli } from 'cleye';
 import { glob } from 'tinyglobby';
-import { generateTypes } from '../plugin/generate-types.js';
-import { writeFileIfChanged } from '../write-file-if-changed.js';
-import { slash } from '../plugin/url-utils.js';
+import { supportsArbitraryModuleNamespace } from '../plugin/supports-arbitrary-module-namespace.js';
 import { createCssModuleLoader } from './load-css-module.js';
+import { generateDeclarationForFile } from './generate-declaration.js';
+import { resolveGlobScope } from './glob-scope.js';
 import {
 	findViteConfigInDirectory,
 	loadProjectContext,
 } from './project-context.js';
-
-const defaultGlob = '**/*.module.{css,scss,sass}';
 
 (async () => {
 	const argv = cli({
@@ -36,12 +34,17 @@ const defaultGlob = '**/*.module.{css,scss,sass}';
 				alias: 's',
 				description: 'Suppress success output',
 			},
+			watch: {
+				type: Boolean,
+				alias: 'w',
+				description: 'Watch for changes and regenerate types',
+			},
 		},
 	});
 
 	const cwd = process.cwd();
 	const { globs: inputGlobs = [] } = argv._;
-	const { config, mode, silent } = argv.flags;
+	const { config, mode, silent, watch: watchMode } = argv.flags;
 	const configPath = config
 		? path.resolve(config)
 		: await findViteConfigInDirectory(cwd);
@@ -55,22 +58,9 @@ const defaultGlob = '**/*.module.{css,scss,sass}';
 		mode,
 	});
 	const { root } = projectContext.resolvedConfig;
+	const allowArbitraryNamedExports = supportsArbitraryModuleNamespace(projectContext.resolvedConfig);
 
-	let globs: string[];
-	let globCwd: string;
-
-	if (inputGlobs.length === 0) {
-		const rootRelative = path.relative(cwd, root);
-		if (rootRelative === '..' || rootRelative.startsWith(`..${path.sep}`) || path.isAbsolute(rootRelative)) {
-			throw new Error(`Resolved Vite root is outside the current working directory: ${root}\nPass explicit globs to control the search scope.`);
-		}
-
-		globs = [defaultGlob];
-		globCwd = root;
-	} else {
-		globs = inputGlobs;
-		globCwd = cwd;
-	}
+	const { globs, globCwd } = resolveGlobScope(inputGlobs, cwd, root);
 
 	const files = await glob(globs, {
 		absolute: true,
@@ -78,38 +68,44 @@ const defaultGlob = '**/*.module.{css,scss,sass}';
 		ignore: ['**/node_modules/**'],
 	});
 
-	if (files.length === 0) {
+	if (files.length === 0 && !watchMode) {
 		console.error('No files matched the provided glob patterns');
 		return;
 	}
 
 	const loadCssModule = createCssModuleLoader(projectContext);
 
-	await Promise.all(files.map(async (filePath) => {
-		const relativePath = slash(path.relative(cwd, filePath));
-		try {
-			const {
-				exports,
-				sourceMapOptions,
-			} = await loadCssModule(filePath);
-			const generatedDts = generateTypes(
-				exports,
-				projectContext.exportMode,
-				false,
-				sourceMapOptions,
-			);
+	await Promise.all(files.map(filePath =>
+		generateDeclarationForFile(
+			projectContext,
+			loadCssModule,
+			cwd,
+			filePath,
+			allowArbitraryNamedExports,
+			silent ?? false,
+			!watchMode,
+		),
+	));
 
-			const dtsPath = `${filePath}.d.ts`;
-			await writeFileIfChanged(dtsPath, generatedDts);
-			if (!silent) {
-				console.log(`\u2713 ${relativePath}.d.ts`);
-			}
-		} catch (error) {
-			console.error(`\u2717 ${relativePath}`);
-			console.error(`  ${(error as Error).message}`);
-			process.exitCode = 1;
-		}
-	}));
+	if (watchMode) {
+		const { runWatch } = await import('./watch.js');
+		const cleanup = await runWatch({
+			globs,
+			globCwd,
+			projectContext,
+			loadCssModule,
+			cwd,
+			allowArbitraryNamedExports,
+			hadInitialMatches: files.length > 0,
+			silent: silent ?? false,
+		});
+
+		const shutdown = () => {
+			cleanup().then(() => process.exit());
+		};
+		process.on('SIGINT', shutdown);
+		process.on('SIGTERM', shutdown);
+	}
 })().catch((error: Error) => {
 	console.error(error.message);
 	process.exitCode = 1;

--- a/src/cli/load-css-module.ts
+++ b/src/cli/load-css-module.ts
@@ -131,5 +131,9 @@ export const createCssModuleLoader = (
 		return cached;
 	};
 
+	loadCssModule.invalidate = (filePath: string) => {
+		cache.delete(filePath);
+	};
+
 	return loadCssModule;
 };

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -1,0 +1,153 @@
+/* eslint-disable no-console */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { subscribe } from '@parcel/watcher';
+import picomatch from 'picomatch';
+import { slash } from '../plugin/url-utils.js';
+import {
+	generateDeclarationForFile,
+	type CssModuleLoader,
+} from './generate-declaration.js';
+import type { ProjectContext } from './project-context.js';
+
+const DEFAULT_IGNORE_DIRS = [
+	'node_modules',
+	'.git',
+	'dist',
+	'coverage',
+] as const;
+
+const DEFAULT_IGNORE_GLOBS = DEFAULT_IGNORE_DIRS.map(
+	dir => `**/${dir}/**`,
+);
+
+export type RunWatchOptions = {
+	globs: string[];
+	globCwd: string;
+	projectContext: ProjectContext;
+	loadCssModule: CssModuleLoader;
+	cwd: string;
+	allowArbitraryNamedExports: boolean;
+	hadInitialMatches: boolean;
+	silent: boolean;
+};
+
+const unlinkIfExists = async (filePath: string) => {
+	await fs.unlink(filePath).catch((error: NodeJS.ErrnoException) => {
+		if (error.code !== 'ENOENT') {
+			throw error;
+		}
+	});
+};
+
+export const runWatch = async ({
+	globs,
+	globCwd,
+	projectContext,
+	loadCssModule,
+	cwd,
+	allowArbitraryNamedExports,
+	hadInitialMatches,
+	silent,
+}: RunWatchOptions): Promise<() => Promise<void>> => {
+	const resolvedGlobCwd = path.resolve(globCwd);
+
+	const globMatchers = globs.map(pattern =>
+		picomatch(pattern, { dot: true }),
+	);
+
+	const matchesConfiguredGlobs = (absolutePath: string): boolean => {
+		const relative = slash(path.relative(resolvedGlobCwd, absolutePath));
+		if (
+			relative === ''
+			|| relative.startsWith('..')
+			|| path.isAbsolute(relative)
+		) {
+			return false;
+		}
+		return globMatchers.some(matcher => matcher(relative));
+	};
+
+	const ignoreMatchers = DEFAULT_IGNORE_GLOBS.map(pattern =>
+		picomatch(pattern, { dot: true }),
+	);
+
+	const isIgnored = (absolutePath: string): boolean => {
+		const relative = slash(path.relative(resolvedGlobCwd, absolutePath));
+		return ignoreMatchers.some(matcher => matcher(relative));
+	};
+
+	const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	const debounce = (filePath: string, callback: () => void) => {
+		clearTimeout(pendingTimers.get(filePath));
+		pendingTimers.set(
+			filePath,
+			setTimeout(() => {
+				pendingTimers.delete(filePath);
+				callback();
+			}, 100),
+		);
+	};
+
+	const handleModify = (absolutePath: string) => {
+		debounce(absolutePath, () => {
+			loadCssModule.invalidate(absolutePath);
+			generateDeclarationForFile(
+				projectContext,
+				loadCssModule,
+				cwd,
+				absolutePath,
+				allowArbitraryNamedExports,
+				silent,
+				false,
+			).catch((error: unknown) => {
+				console.error(error);
+			});
+		});
+	};
+
+	const sub = await subscribe(
+		resolvedGlobCwd,
+		(error, events) => {
+			if (error) {
+				console.error(error);
+				return;
+			}
+			for (const event of events) {
+				if (isIgnored(event.path)) {
+					continue;
+				}
+				if (!matchesConfiguredGlobs(event.path)) {
+					continue;
+				}
+
+				if (event.type === 'create' || event.type === 'update') {
+					handleModify(event.path);
+				} else if (event.type === 'delete') {
+					loadCssModule.invalidate(event.path);
+					Promise.all([
+						unlinkIfExists(`${event.path}.d.ts`),
+						unlinkIfExists(`${event.path}.d.ts.map`),
+					]).catch((unlinkError: unknown) => {
+						console.error(unlinkError instanceof Error ? unlinkError.message : unlinkError);
+					});
+				}
+			}
+		},
+		{
+			ignore: DEFAULT_IGNORE_DIRS.map(dir => path.join(resolvedGlobCwd, dir)),
+		},
+	);
+
+	if (!hadInitialMatches && !silent) {
+		console.log('No files matched yet; watching for additions.');
+	}
+	console.log('Watching for changes...');
+
+	return async () => {
+		pendingTimers.forEach(clearTimeout);
+		pendingTimers.clear();
+		await sub.unsubscribe();
+	};
+};
+/* eslint-enable no-console */

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -52,9 +52,7 @@ export const runWatch = async ({
 }: RunWatchOptions): Promise<() => Promise<void>> => {
 	const resolvedGlobCwd = path.resolve(globCwd);
 
-	const globMatchers = globs.map(pattern =>
-		picomatch(pattern, { dot: true }),
-	);
+	const globMatchers = globs.map(pattern => picomatch(pattern, { dot: true }));
 
 	const matchesConfiguredGlobs = (absolutePath: string): boolean => {
 		const relative = slash(path.relative(resolvedGlobCwd, absolutePath));
@@ -68,9 +66,7 @@ export const runWatch = async ({
 		return globMatchers.some(matcher => matcher(relative));
 	};
 
-	const ignoreMatchers = DEFAULT_IGNORE_GLOBS.map(pattern =>
-		picomatch(pattern, { dot: true }),
-	);
+	const ignoreMatchers = DEFAULT_IGNORE_GLOBS.map(pattern => picomatch(pattern, { dot: true }));
 
 	const isIgnored = (absolutePath: string): boolean => {
 		const relative = slash(path.relative(resolvedGlobCwd, absolutePath));

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -81,7 +81,7 @@ export const runWatch = async ({
 			setTimeout(() => {
 				pendingTimers.delete(filePath);
 				callback();
-			}, 300),
+			}, 100),
 		);
 	};
 

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -81,7 +81,7 @@ export const runWatch = async ({
 			setTimeout(() => {
 				pendingTimers.delete(filePath);
 				callback();
-			}, 100),
+			}, 300),
 		);
 	};
 

--- a/tests/specs/cli.spec.ts
+++ b/tests/specs/cli.spec.ts
@@ -1071,12 +1071,12 @@ export default {
 				await watcher.waitForOutput('style.module.css.d.ts');
 
 				const poll = async () => {
-					for (let i = 0; i < 50; i++) {
+					for (let i = 0; i < 50; i += 1) {
 						const content = await fixture.readFile('style.module.css.d.ts', 'utf8');
 						if (content.includes('updated')) {
 							return content;
 						}
-						await new Promise(resolve => setTimeout(resolve, 100));
+						await new Promise((resolve) => { setTimeout(resolve, 100); });
 					}
 					throw new Error('Timed out waiting for updated .d.ts content');
 				};
@@ -1105,14 +1105,14 @@ export default {
 				await fs.unlink(path.join(fixture.path, 'style.module.css'));
 
 				const poll = async () => {
-					for (let i = 0; i < 50; i++) {
+					for (let i = 0; i < 50; i += 1) {
 						const exists = await fs.access(
 							path.join(fixture.path, 'style.module.css.d.ts'),
 						).then(() => true, () => false);
 						if (!exists) {
 							return;
 						}
-						await new Promise(resolve => setTimeout(resolve, 100));
+						await new Promise((resolve) => { setTimeout(resolve, 100); });
 					}
 					throw new Error('Timed out waiting for .d.ts deletion');
 				};
@@ -1158,14 +1158,14 @@ export default {
 				);
 
 				const poll = async () => {
-					for (let i = 0; i < 50; i++) {
+					for (let i = 0; i < 50; i += 1) {
 						const exists = await fs.access(
 							path.join(fixture.path, 'style.module.css.d.ts'),
 						).then(() => true, () => false);
 						if (exists) {
 							return;
 						}
-						await new Promise(resolve => setTimeout(resolve, 100));
+						await new Promise((resolve) => { setTimeout(resolve, 100); });
 					}
 					throw new Error('Timed out waiting for .d.ts generation');
 				};

--- a/tests/specs/cli.spec.ts
+++ b/tests/specs/cli.spec.ts
@@ -1014,6 +1014,15 @@ export default {
 				});
 			};
 
+			// On Windows, @parcel/watcher's subscribe() resolves before
+			// ReadDirectoryChangesW is called (queued via QueueUserAPC).
+			const waitUntilReady = async () => {
+				await waitForOutput('Watching for changes...');
+				if (process.platform === 'win32') {
+					await new Promise((resolve) => { setTimeout(resolve, 1000); });
+				}
+			};
+
 			return {
 				get stdout() {
 					return stdout;
@@ -1022,6 +1031,7 @@ export default {
 					return stderr;
 				},
 				waitForOutput,
+				waitUntilReady,
 				kill,
 			};
 		};
@@ -1034,7 +1044,7 @@ export default {
 
 			const watcher = watchCli(['**/*.module.css'], fixture.path);
 			try {
-				await watcher.waitForOutput('Watching for changes...');
+				await watcher.waitUntilReady();
 
 				await fs.writeFile(
 					path.join(fixture.path, 'new.module.css'),
@@ -1058,7 +1068,7 @@ export default {
 
 			const watcher = watchCli(['**/*.module.css'], fixture.path);
 			try {
-				await watcher.waitForOutput('Watching for changes...');
+				await watcher.waitUntilReady();
 
 				const dtsBefore = await fixture.readFile('style.module.css.d.ts', 'utf8');
 				expect(dtsBefore).toMatch('declare const original: string');
@@ -1096,7 +1106,7 @@ export default {
 
 			const watcher = watchCli(['**/*.module.css'], fixture.path);
 			try {
-				await watcher.waitForOutput('Watching for changes...');
+				await watcher.waitUntilReady();
 
 				expect(
 					await fixture.readFile('style.module.css.d.ts', 'utf8').catch(() => null),
@@ -1130,7 +1140,7 @@ export default {
 
 			const watcher = watchCli(['--silent', '**/*.module.css'], fixture.path);
 			try {
-				await watcher.waitForOutput('Watching for changes...');
+				await watcher.waitUntilReady();
 
 				await fs.writeFile(
 					path.join(fixture.path, 'broken.module.css'),
@@ -1150,7 +1160,7 @@ export default {
 
 			const watcher = watchCli(['--silent', '**/*.module.css'], fixture.path);
 			try {
-				await watcher.waitForOutput('Watching for changes...');
+				await watcher.waitUntilReady();
 
 				await fs.writeFile(
 					path.join(fixture.path, 'style.module.css'),
@@ -1184,7 +1194,7 @@ export default {
 
 			const watcher = watchCli(['**/*.module.css'], fixture.path);
 			try {
-				await watcher.waitForOutput('Watching for changes...');
+				await watcher.waitUntilReady();
 				expect(watcher.stdout).toMatch('No files matched yet');
 
 				await fs.writeFile(

--- a/tests/specs/cli.spec.ts
+++ b/tests/specs/cli.spec.ts
@@ -1,4 +1,6 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
+import { spawn as cpSpawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { decode } from '@jridgewell/sourcemap-codec';
 import { createFixture, type FileTree } from 'fs-fixture';
@@ -960,6 +962,242 @@ export default {
 			// exportMode: 'named' means named exports only, no default export
 			expect(dts).toMatch('export {');
 			expect(dts).not.toMatch('export default');
+		});
+	});
+
+	describe('watch mode', () => {
+		const watchCli = (
+			args: string[],
+			cwd: string,
+		) => {
+			const child = cpSpawn(process.execPath, [cliPath, '--watch', ...args], {
+				cwd,
+				stdio: ['ignore', 'pipe', 'pipe'],
+			});
+
+			let stdout = '';
+			let stderr = '';
+			child.stdout!.on('data', (chunk: Buffer) => {
+				stdout += chunk.toString();
+			});
+			child.stderr!.on('data', (chunk: Buffer) => {
+				stderr += chunk.toString();
+			});
+
+			const waitForOutput = (
+				match: string | RegExp,
+				stream: 'stdout' | 'stderr' = 'stdout',
+				timeout = 15_000,
+			) => new Promise<void>((resolve, reject) => {
+				const timer = setTimeout(
+					() => reject(new Error(`Timed out waiting for ${String(match)} in ${stream}.\nstdout: ${stdout}\nstderr: ${stderr}`)),
+					timeout,
+				);
+
+				const check = () => {
+					const text = stream === 'stdout' ? stdout : stderr;
+					const matched = typeof match === 'string' ? text.includes(match) : match.test(text);
+					if (matched) {
+						clearTimeout(timer);
+						resolve();
+					}
+				};
+
+				check();
+				child[stream]!.on('data', check);
+			});
+
+			const kill = () => {
+				child.kill('SIGTERM');
+				return new Promise<void>((resolve) => {
+					child.on('close', () => resolve());
+				});
+			};
+
+			return {
+				get stdout() {
+					return stdout;
+				},
+				get stderr() {
+					return stderr;
+				},
+				waitForOutput,
+				kill,
+			};
+		};
+
+		test('generates types for new files', async () => {
+			await using fixture = await createFixture({
+				...defaultProjectFiles,
+				'existing.module.css': '.existing { color: red; }',
+			});
+
+			const watcher = watchCli(['**/*.module.css'], fixture.path);
+			try {
+				await watcher.waitForOutput('Watching for changes...');
+
+				await fs.writeFile(
+					path.join(fixture.path, 'new.module.css'),
+					'.added { color: blue; }',
+				);
+
+				await watcher.waitForOutput('new.module.css.d.ts');
+
+				const dts = await fixture.readFile('new.module.css.d.ts', 'utf8');
+				expect(dts).toMatch('declare const added: string');
+			} finally {
+				await watcher.kill();
+			}
+		});
+
+		test('regenerates types on file change', async () => {
+			await using fixture = await createFixture({
+				...defaultProjectFiles,
+				'style.module.css': '.original { color: red; }',
+			});
+
+			const watcher = watchCli(['**/*.module.css'], fixture.path);
+			try {
+				await watcher.waitForOutput('Watching for changes...');
+
+				const dtsBefore = await fixture.readFile('style.module.css.d.ts', 'utf8');
+				expect(dtsBefore).toMatch('declare const original: string');
+
+				await fs.writeFile(
+					path.join(fixture.path, 'style.module.css'),
+					'.updated { color: blue; }',
+				);
+
+				await watcher.waitForOutput('style.module.css.d.ts');
+
+				const poll = async () => {
+					for (let i = 0; i < 50; i++) {
+						const content = await fixture.readFile('style.module.css.d.ts', 'utf8');
+						if (content.includes('updated')) {
+							return content;
+						}
+						await new Promise(resolve => setTimeout(resolve, 100));
+					}
+					throw new Error('Timed out waiting for updated .d.ts content');
+				};
+				const dtsAfter = await poll();
+				expect(dtsAfter).toMatch('declare const updated: string');
+				expect(dtsAfter).not.toMatch('declare const original: string');
+			} finally {
+				await watcher.kill();
+			}
+		});
+
+		test('removes .d.ts on file deletion', async () => {
+			await using fixture = await createFixture({
+				...defaultProjectFiles,
+				'style.module.css': '.button { color: red; }',
+			});
+
+			const watcher = watchCli(['**/*.module.css'], fixture.path);
+			try {
+				await watcher.waitForOutput('Watching for changes...');
+
+				expect(
+					await fixture.readFile('style.module.css.d.ts', 'utf8').catch(() => null),
+				).not.toBe(null);
+
+				await fs.unlink(path.join(fixture.path, 'style.module.css'));
+
+				const poll = async () => {
+					for (let i = 0; i < 50; i++) {
+						const exists = await fs.access(
+							path.join(fixture.path, 'style.module.css.d.ts'),
+						).then(() => true, () => false);
+						if (!exists) {
+							return;
+						}
+						await new Promise(resolve => setTimeout(resolve, 100));
+					}
+					throw new Error('Timed out waiting for .d.ts deletion');
+				};
+				await poll();
+			} finally {
+				await watcher.kill();
+			}
+		});
+
+		test('errors are shown even with --silent', async () => {
+			await using fixture = await createFixture({
+				...defaultProjectFiles,
+				'style.module.css': '.button { color: red; }',
+			});
+
+			const watcher = watchCli(['--silent', '**/*.module.css'], fixture.path);
+			try {
+				await watcher.waitForOutput('Watching for changes...');
+
+				await fs.writeFile(
+					path.join(fixture.path, 'broken.module.css'),
+					'.button { color: ',
+				);
+
+				await watcher.waitForOutput('broken.module.css', 'stderr');
+			} finally {
+				await watcher.kill();
+			}
+		});
+
+		test('--silent suppresses success output in watch mode', async () => {
+			await using fixture = await createFixture({
+				...defaultProjectFiles,
+			});
+
+			const watcher = watchCli(['--silent', '**/*.module.css'], fixture.path);
+			try {
+				await watcher.waitForOutput('Watching for changes...');
+
+				await fs.writeFile(
+					path.join(fixture.path, 'style.module.css'),
+					'.button { color: red; }',
+				);
+
+				const poll = async () => {
+					for (let i = 0; i < 50; i++) {
+						const exists = await fs.access(
+							path.join(fixture.path, 'style.module.css.d.ts'),
+						).then(() => true, () => false);
+						if (exists) {
+							return;
+						}
+						await new Promise(resolve => setTimeout(resolve, 100));
+					}
+					throw new Error('Timed out waiting for .d.ts generation');
+				};
+				await poll();
+
+				expect(watcher.stdout).not.toMatch('style.module.css.d.ts');
+			} finally {
+				await watcher.kill();
+			}
+		});
+
+		test('watch starts even with no initial files', async () => {
+			await using fixture = await createFixture({
+				...defaultProjectFiles,
+			});
+
+			const watcher = watchCli(['**/*.module.css'], fixture.path);
+			try {
+				await watcher.waitForOutput('Watching for changes...');
+				expect(watcher.stdout).toMatch('No files matched yet');
+
+				await fs.writeFile(
+					path.join(fixture.path, 'new.module.css'),
+					'.fresh { color: green; }',
+				);
+
+				await watcher.waitForOutput('new.module.css.d.ts');
+				const dts = await fixture.readFile('new.module.css.d.ts', 'utf8');
+				expect(dts).toMatch('declare const fresh: string');
+			} finally {
+				await watcher.kill();
+			}
 		});
 	});
 }, { parallel: 4 });


### PR DESCRIPTION
Closes #110 


## Summary

Adds `--watch` / `-w` flag to the CLI. When enabled, `.d.ts` files are generated/updated/removed in real-time as `.module.css` files are created, modified, or deleted — no browser or manual re-run needed.

```sh
npx vite-css-modules --watch
npx vite-css-modules -w "src/**/*.module.css"
```

## Motivation

In large projects you frequently create or edit `.module.css` files and expect TypeScript types immediately. Today you must either load the page in the browser (so the transform hook fires) or re-run the CLI manually. Neither works well during active development.

## How it works

1. Run the existing one-shot generation for all matched files
2. Start an OS-level file watcher on the glob scope directory
3. On create/update: invalidate the loader cache, regenerate the `.d.ts`
4. On delete: remove both `.d.ts` and `.d.ts.map`
5. Ctrl+C cleanly unsubscribes the watcher and exits

## Design decisions

### File watcher: `@parcel/watcher`

Evaluated three options:
- **`@parcel/watcher`** (chosen) — native C++ bindings using OS-level APIs (FSEvents/inotify/ReadDirectoryChanges). Delivers batched events via a callback, no "ready" event ceremony needed. `subscribe()` is async — watcher is live once the promise resolves.
- **`chokidar`** — pure JS, most popular. But v5 dropped glob support and the `ignored` option no longer accepts globs, requiring manual workarounds. Also hit EMFILE errors when symlinked `node_modules` caused recursive watching.
- **Node `fs.watch`** — zero deps but unreliable cross-platform (duplicate events, no recursive on Linux < Node 20).

### Glob matching: `picomatch`

`@parcel/watcher` watches a directory and reports all events. We filter with `picomatch` matchers against the user's glob patterns, using `slash()` to normalize paths on Windows.

### Debounce: 100ms per-file

Editors often emit multiple FS events for a single save (write temp → rename). Per-file debounce at 100ms prevents partial reads and redundant work without delaying unrelated files. Evaluated 30ms (too aggressive for VS Code's write patterns) and chokidar's `awaitWriteFinish` (polling-based, adds latency).

### Error handling

- **One-shot mode**: errors set `process.exitCode = 1` (existing behavior)
- **Watch mode**: errors log to stderr and continue watching (`failOnError: false`). Errors always print regardless of `--silent`.

### Ignored directories

`node_modules`, `.git`, `dist`, `coverage` — passed to `@parcel/watcher`'s native ignore (so the OS never reports events from them) and also checked at runtime via picomatch as a safety net.

## Refactoring

Extracted shared logic so one-shot and watch modes use the same code paths:

- **`generate-declaration.ts`** — single-file type generation with `failOnError` and `allowArbitraryNamedExports` params (previously `allowArbitraryNamedExports` was hardcoded to `false` in the CLI)
- **`glob-scope.ts`** — resolves user globs + cwd vs config root logic
- **`load-css-module.ts`** — added `invalidate()` method to clear the transform cache for a specific file (required for watch to re-process changed files)

## New dependencies

| Dep | Type | Why |
|-----|------|-----|
| `@parcel/watcher` | prod | OS-native file watching |
| `picomatch` | prod | Glob matching for watcher events |
| `@types/picomatch` | dev | Type definitions |

## Tests

6 new tests covering:
- Generates types for newly created files
- Regenerates types when existing files change
- Removes `.d.ts` when source file is deleted
- Errors shown even with `--silent`
- Success output suppressed with `--silent`
- Watch starts and works when no files match initially (prints "No files matched yet; watching for additions.")

All 44 existing CLI tests continue to pass.

---


### NOTE: I used AI to help me